### PR TITLE
Typo ordenation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 .aiox-core/
 
 teste.js
-# teste.ts
+teste.ts
+teste-class.ts
 
 linkedin/

--- a/README-DynamicRepo.md
+++ b/README-DynamicRepo.md
@@ -142,10 +142,10 @@ The `@DynamicMethod<M>()` decorator accepts an optional config object:
 
 ```typescript
 @DynamicMethod<"User">({
-    proxyTo: "findByEmail",           // Delegate to another method pattern
-    whereType: "overwrite",           // "extending" (default) or "overwrite"
-    pushWhere: { active: false },      // Extra where clause
-    injectOrdenation: [{ name: "asc" }],  // Fixed ordering
+    proxyTo: "findByEmail",                   // Delegate to another method pattern
+    whereType: "overwrite",                   // "extending" (default) or "overwrite"
+    pushWhere: { active: false },             // Extra where clause
+    injectOrdering: [{ name: "asc" }],        // Fixed ordering
     injectPagination: { skip: 0, take: 10 },  // Fixed pagination
 })
 ```
@@ -155,7 +155,7 @@ The `@DynamicMethod<M>()` decorator accepts an optional config object:
 | `proxyTo`          | `string`                     | Delegates to another valid method pattern (e.g. `"findOneByEmail"`)                                               |
 | `whereType`        | `"extending" \| "overwrite"` | `extending` combines with `requiredWhere`; `overwrite` ignores it                                                 |
 | `pushWhere`        | `WhereModel<M>`              | Extra `where` clause added on top of `requiredWhere`                                                              |
-| `injectOrdenation` | `OrdenationModel<M>`         | Fixed ordering injected into the query                                                                            |
+| `injectOrdering`   | `OrderingModel<M>`           | Fixed ordering injected into the query                                                                            |
 | `injectPagination` | `PaginationModel<M>`         | Fixed pagination injected into the query                                                                          |
 | `fbMode`           | `"one" \| "list"`            | **Deprecated.** Only relevant for `findBy`-prefixed methods. Use `findOneBy` instead if you want a single result. |
 
@@ -195,7 +195,7 @@ Since `@QueryMethod` skips name parsing, there's no automatic type inference for
 | `options.modifying`    | `boolean` | `false` | When `true`, runs via `$executeRawUnsafe`; the field must be declared to return `Promise<number>`. When `false`, runs via `$queryRawUnsafe`. |
 
 > [!NOTE]
-> `@QueryMethod` ignores every other dynamic-method concept — `requiredWhere`, `pushWhere`, `whereType`, `selectModels`/`includeModels`, `injectOrdenation`, `injectPagination`. None of it applies here.
+> `@QueryMethod` ignores every other dynamic-method concept — `requiredWhere`, `pushWhere`, `whereType`, `selectModels`/`includeModels`, `injectOrdering`, `injectPagination`. None of it applies here.
 
 ---
 
@@ -225,7 +225,7 @@ All `DynamicRepository` instances automatically include these methods:
 
 All methods accept an optional `options` argument based on `DynamicMethodOptions` (`db`, `see`, `include`, `select`), but a few methods narrow it further:
 
-- **`getAll`** additionally accepts `pagination?: PaginationOptions` and `order?: OrdenationModel<UName>` (falls back to `defaultOrdenation` when omitted).
+- **`getAll`** additionally accepts `pagination?: PaginationOptions` and `order?: OrderingModel<UName>` (falls back to `defaultOrdering` when omitted).
 - **`saveList` / `patchList`** omit `include` and `select`, and `db` only accepts a `DbTransaction` (the return of `prisma.$transaction`) — not the plain Prisma client.
 - **`removeList`, `total`, `has`** omit `include` and `select`.
 - **`softRemove`, `restore`** omit `see` (soft-delete visibility doesn't apply to the record being changed).
@@ -559,7 +559,7 @@ constructor(prisma: DbClient, config: DynamicRepositoryConstructorConfig<TEntity
 | `pkName`             | `keyof TEntity`                | Primary key field              |
 | `softRemovekName?`   | `keyof TEntity`                | DateTime field for soft-delete |
 | `requiredWhere?`     | `WhereModel<UName>`            | Global filters                 |
-| `defaultOrdenation?` | `OrdenationModel<UName>`       | Default ordering               |
+| `defaultOrdering?`   | `OrderingModel<UName>`         | Default ordering               |
 | `relations?`         | `RepositoryRelations<TEntity>` | Relation configuration         |
 | `build?`             | `DynamicRepositoryBuildConfig` | Build-time options             |
 

--- a/README-DynamicRepo.pt-BR.md
+++ b/README-DynamicRepo.pt-BR.md
@@ -142,10 +142,10 @@ O decorator `@DynamicMethod<M>()` aceita um objeto de configuração opcional:
 
 ```typescript
 @DynamicMethod<"User">({
-    proxyTo: "findByEmail",           // Delega para outro padrão de método
-    whereType: "overwrite",           // "extending" (padrão) ou "overwrite"
-    pushWhere: { active: false },      // Cláusula where extra
-    injectOrdenation: [{ name: "asc" }],  // Ordenação fixa
+    proxyTo: "findByEmail",                   // Delega para outro padrão de método
+    whereType: "overwrite",                   // "extending" (padrão) ou "overwrite"
+    pushWhere: { active: false },             // Cláusula where extra
+    injectOrdering: [{ name: "asc" }],        // Ordenação fixa
     injectPagination: { skip: 0, take: 10 },  // Paginação fixa
 })
 ```
@@ -155,7 +155,7 @@ O decorator `@DynamicMethod<M>()` aceita um objeto de configuração opcional:
 | `proxyTo`          | `string`                     | Delega para outro padrão de método válido (ex.: `"findOneByEmail"`)                                                            |
 | `whereType`        | `"extending" \| "overwrite"` | `extending` combina com `requiredWhere`; `overwrite` o ignora                                                                  |
 | `pushWhere`        | `WhereModel<M>`              | Cláusula `where` extra adicionada além do `requiredWhere`                                                                      |
-| `injectOrdenation` | `OrdenationModel<M>`         | Ordenação fixa injetada na query                                                                                               |
+| `injectOrdering`   | `OrderingModel<M>`           | Ordenação fixa injetada na query                                                                                               |
 | `injectPagination` | `PaginationModel<M>`         | Paginação fixa injetada na query                                                                                               |
 | `fbMode`           | `"one" \| "list"`            | **Deprecated.** Relevante apenas para métodos com prefixo `findBy`. Use `findOneBy` em vez disso se quiser um resultado único. |
 
@@ -195,7 +195,7 @@ Como `@QueryMethod` pula o parsing de nome, não há inferência automática de 
 | `options.modifying`    | `boolean` | `false` | Quando `true`, executa via `$executeRawUnsafe`; o campo deve ser declarado retornando `Promise<number>`. Quando `false`, executa via `$queryRawUnsafe`. |
 
 > [!NOTE]
-> `@QueryMethod` ignora todos os outros conceitos de método dinâmico — `requiredWhere`, `pushWhere`, `whereType`, `selectModels`/`includeModels`, `injectOrdenation`, `injectPagination`. Nada disso se aplica aqui.
+> `@QueryMethod` ignora todos os outros conceitos de método dinâmico — `requiredWhere`, `pushWhere`, `whereType`, `selectModels`/`includeModels`, `injectOrdering`, `injectPagination`. Nada disso se aplica aqui.
 
 ---
 
@@ -225,7 +225,7 @@ Todas as instâncias de `DynamicRepository` incluem automaticamente estes métod
 
 Todos os métodos aceitam um argumento opcional `options` baseado em `DynamicMethodOptions` (`db`, `see`, `include`, `select`), mas alguns métodos restringem esse tipo:
 
-- **`getAll`** aceita adicionalmente `pagination?: PaginationOptions` e `order?: OrdenationModel<UName>` (usa `defaultOrdenation` quando omitido).
+- **`getAll`** aceita adicionalmente `pagination?: PaginationOptions` e `order?: OrderingModel<UName>` (usa `defaultOrdering` quando omitido).
 - **`saveList` / `patchList`** omitem `include` e `select`, e `db` só aceita uma `DbTransaction` (o retorno de `prisma.$transaction`) — não o client Prisma comum.
 - **`removeList`, `total`, `has`** omitem `include` e `select`.
 - **`softRemove`, `restore`** omitem `see` (a visibilidade de soft-delete não se aplica ao registro sendo alterado).
@@ -559,7 +559,7 @@ constructor(prisma: DbClient, config: DynamicRepositoryConstructorConfig<TEntity
 | `pkName`             | `keyof TEntity`                | Campo da chave primária         |
 | `softRemovekName?`   | `keyof TEntity`                | Campo DateTime para soft-delete |
 | `requiredWhere?`     | `WhereModel<UName>`            | Filtros globais                 |
-| `defaultOrdenation?` | `OrdenationModel<UName>`       | Ordenação padrão                |
+| `defaultOrdering?`   | `OrderingModel<UName>`         | Ordenação padrão                |
 | `relations?`         | `RepositoryRelations<TEntity>` | Configuração de relações        |
 | `build?`             | `DynamicRepositoryBuildConfig` | Opções de build                 |
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ VSRepository lets you create strongly-typed repositories with:
 - [Include Models](#include-models)
   - [Raw include (options.include)](#raw-include-optionsinclude)
 - [Required Where](#required-where)
-- [Default Ordenation](#default-ordenation)
+- [Default Ordering](#default-ordering)
 - [`see` option](#see-option)
 - [Dynamic methods](#dynamic-methods)
   - [Available prefixes](#available-prefixes)
@@ -661,15 +661,15 @@ Useful for manual soft-deletes, multi-tenancy, and global filters of any kind.
 
 ---
 
-## Default Ordenation
+## Default Ordering
 
-`defaultOrdenation` defines a default ordering that's automatically applied to every query that accepts `orderBy`, without needing to repeat the `order` argument on every call.
+`defaultOrdering` defines a default ordering that's automatically applied to every query that accepts `orderBy`, without needing to repeat the `order` argument on every call.
 
 ```ts
 const userRepository = setupVSRepo<User, "user">()(({
   tableName: "user",
   pkName: "id",
-  defaultOrdenation: { createdAt: "desc" },
+  defaultOrdering: { createdAt: "desc" },
 }).build(prisma);
 ```
 
@@ -683,23 +683,23 @@ const users = await userRepository.getAll();
 const paginated = await userRepository.getAll({ pagination: { take: 10 } });
 ```
 
-**`defaultOrdenation` is ignored when:**
+**`defaultOrdering` is ignored when:**
 
 - The method uses the `Ordered`, `OrderedAndPaginated`, or `PaginatedAndOrdered` suffix — in these cases the `order` argument passed in the call takes priority.
-- The dynamic method has `injectOrdenation` configured — the method's fixed ordering takes precedence.
+- The dynamic method has `injectOrdering` configured — the method's fixed ordering takes precedence.
 
 ```ts
 methods: {
-  findManyPaginatedAndOrdered: { map: true },         // order comes from the argument → defaultOrdenation ignored
-  findManyByActive:            { map: true },         // no Ordered → defaultOrdenation applied
+  findManyPaginatedAndOrdered: { map: true },         // order comes from the argument → defaultOrdering ignored
+  findManyByActive:            { map: true },         // no Ordered → defaultOrdering applied
   findManyByStatus: {
     map: true,
-    injectOrdenation: { name: "asc" },                // injectOrdenation → defaultOrdenation ignored
+    injectOrdering: { name: "asc" },                  // injectOrdering → defaultOrdering ignored
   },
 }
 ```
 
-> `defaultOrdenation` accepts the same type as Prisma's native `orderBy` for the model — including arrays of chained orderings.
+> `defaultOrdering` accepts the same type as Prisma's native `orderBy` for the model — including arrays of chained orderings.
 
 ---
 
@@ -1086,7 +1086,7 @@ Each entry in `methods` accepts the following options:
 | `fbMode`              | `'one'` \| `'list'`                      | `'list'`       | (**Deprecated. Use `findOneBy`**) Only for `findBy`. `'one'` returns `T \| null`; `'list'` returns `T[]`.                   |
 | `proxyTo`             | `Valid method pattern`                   | —              | Delegates the logic to another valid method pattern.                                                                        |
 | `pushWhere`           | `WhereModel<M>`                          | —              | Extra `where` added to the query in addition to `requiredWhere`.                                                            |
-| `injectOrdenation`    | `OrdenationModel<M>`                     | —              | Fixed ordering automatically injected into the query.                                                                       |
+| `injectOrdering`      | `OrderingModel<M>`                       | —              | Fixed ordering automatically injected into the query.                                                                       |
 | `injectPagination`    | `PaginationModel<M>`                     | —              | Fixed pagination automatically injected into the query.                                                                     |
 | `query`               | `{ value: string; modifying?: boolean }` | —              | Turns the method into a **Query Method** (raw SQL). Ignores every other option above — see [Query Methods](#query-methods). |
 
@@ -1176,7 +1176,7 @@ await userRepository.prisma.$transaction(async (tx) => {
 | `modifying`   | `boolean` | `false` | When `true`, executes via `$executeRawUnsafe` and the method always resolves to `number`. When `false`, executes via `$queryRawUnsafe` and the method resolves to `TReturn` (`any` by default, inferable via a generic at the call site). |
 
 > [!NOTE]
-> Unlike the other dynamic methods, Query Methods **completely ignore** `selectModels`, `requiredWhere`, `pushWhere`, `whereType`, `injectOrdenation`, `injectPagination`, and `proxyTo` — none of that applies, since there's no name parsing or `where`/`select` assembly by VSRepository. Free-form method names (outside the `findBy`, `updateBy`, etc. patterns) also **don't** require `proxyTo`.
+> Unlike the other dynamic methods, Query Methods **completely ignore** `selectModels`, `requiredWhere`, `pushWhere`, `whereType`, `injectOrdering`, `injectPagination`, and `proxyTo` — none of that applies, since there's no name parsing or `where`/`select` assembly by VSRepository. Free-form method names (outside the `findBy`, `updateBy`, etc. patterns) also **don't** require `proxyTo`.
 
 The same functionality is available in the class-based approach via the `@QueryMethod` decorator — see [README-DynamicRepo.md](./README-DynamicRepo.md#the-querymethod-decorator).
 
@@ -1388,7 +1388,7 @@ import type {
   IncludeModel,
   IncludeModels,
   WhereModel,
-  OrdenationModel,
+  OrderingModel,
   PaginationModel,
   ModelUpsertInput,
   PrismaModelInputs,
@@ -1471,7 +1471,7 @@ setupVSRepo<TPayload, TTableName>()({
   defaultSelectModel?: keyof SM;                  // Select applied by default
   includeModels?: IncludeModels<M>;               // Named data projections (include) — no default, only in the call
   requiredWhere?: WhereModel<M>;                  // Always-applied filters
-  defaultOrdenation?: OrdenationModel<M>;         // Default ordering for queries without Ordered/injectOrdenation
+  defaultOrdering?: OrderingModel<M>;             // Default ordering for queries without Ordered/injectOrdering
   relations?: RepositoryRelations<T>;             // Relation configuration
   methods?: Record<string, MethodConfig<M, SM>>;  // Dynamic methods
 });
@@ -1593,7 +1593,7 @@ Recommended `tsconfig.json`:
 
 **`softRemovekName` throws an error at build** — The provided field must be of type `DateTime` in the Prisma schema. Types like `Boolean` or `String` are not accepted.
 
-**`defaultOrdenation` isn't being applied** — Check whether the method uses the `Ordered`, `OrderedAndPaginated`, or `PaginatedAndOrdered` suffix, and whether it has `injectOrdenation` configured. Both take priority over the default ordering.
+**`defaultOrdering` isn't being applied** — Check whether the method uses the `Ordered`, `OrderedAndPaginated`, or `PaginatedAndOrdered` suffix, and whether it has `injectOrdering` configured. Both take priority over the default ordering.
 
 **`Distinct` suffix not recognized** — `Distinct` is only resolved on read prefixes (`findMany`, `findFirst`, `findBy`, `existsBy`, etc). In methods like `count`, `createMany`, `updateMany`, or `deleteMany` the suffix is ignored.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -39,7 +39,7 @@ O VSRepository permite criar repositórios fortemente tipados com:
 - [Include Models](#include-models)
   - [Include bruto (options.include)](#include-bruto-optionsinclude)
 - [Required Where](#required-where)
-- [Ordenação padrão (Default Ordenation)](#ordenação-padrão-default-ordenation)
+- [Ordenação padrão (Default Ordering)](#ordenação-padrão-default-ordering)
 - [Opção `see`](#opção-see)
 - [Métodos dinâmicos](#métodos-dinâmicos)
   - [Prefixos disponíveis](#prefixos-disponíveis)
@@ -661,15 +661,15 @@ const user = await userRepository.findByEmail("john@email.com");
 
 ---
 
-## Ordenação padrão (Default Ordenation)
+## Ordenação padrão (Default Ordering)
 
-`defaultOrdenation` define uma ordenação padrão que é aplicada automaticamente em toda query que aceita `orderBy`, sem precisar repetir o argumento `order` em cada chamada.
+`defaultOrdering` define uma ordenação padrão que é aplicada automaticamente em toda query que aceita `orderBy`, sem precisar repetir o argumento `order` em cada chamada.
 
 ```ts
 const userRepository = setupVSRepo<User, "user">()(({
   tableName: "user",
   pkName: "id",
-  defaultOrdenation: { createdAt: "desc" },
+  defaultOrdering: { createdAt: "desc" },
 }).build(prisma);
 ```
 
@@ -683,23 +683,23 @@ const users = await userRepository.getAll();
 const paginated = await userRepository.getAll({ pagination: { take: 10 } });
 ```
 
-**`defaultOrdenation` é ignorado quando:**
+**`defaultOrdering` é ignorado quando:**
 
 - O método usa o sufixo `Ordered`, `OrderedAndPaginated` ou `PaginatedAndOrdered` — nesses casos, o argumento `order` passado na chamada tem prioridade.
-- O método dinâmico tem `injectOrdenation` configurado — a ordenação fixa do método tem precedência.
+- O método dinâmico tem `injectOrdering` configurado — a ordenação fixa do método tem precedência.
 
 ```ts
 methods: {
-  findManyPaginatedAndOrdered: { map: true },         // order vem do argumento → defaultOrdenation ignorado
-  findManyByActive:            { map: true },         // sem Ordered → defaultOrdenation aplicado
+  findManyPaginatedAndOrdered: { map: true },         // order vem do argumento → defaultOrdering ignorado
+  findManyByActive:            { map: true },         // sem Ordered → defaultOrdering aplicado
   findManyByStatus: {
     map: true,
-    injectOrdenation: { name: "asc" },                // injectOrdenation → defaultOrdenation ignorado
+    injectOrdering: { name: "asc" },                  // injectOrdering → defaultOrdering ignorado
   },
 }
 ```
 
-> `defaultOrdenation` aceita o mesmo tipo do `orderBy` nativo do Prisma para o modelo — incluindo arrays de ordenações encadeadas.
+> `defaultOrdering` aceita o mesmo tipo do `orderBy` nativo do Prisma para o modelo — incluindo arrays de ordenações encadeadas.
 
 ---
 
@@ -1086,7 +1086,7 @@ Cada entrada em `methods` aceita as seguintes opções:
 | `fbMode`              | `'one'` \| `'list'`                      | `'list'`       | (**Deprecated. Use `findOneBy`**) Apenas para `findBy`. `'one'` retorna `T \| null`; `'list'` retorna `T[]`.                        |
 | `proxyTo`             | `Padrão de método válido`                | —              | Delega a lógica para outro padrão de método válido.                                                                                 |
 | `pushWhere`           | `WhereModel<M>`                          | —              | `where` extra adicionado à query além do `requiredWhere`.                                                                           |
-| `injectOrdenation`    | `OrdenationModel<M>`                     | —              | Ordenação fixa injetada automaticamente na query.                                                                                   |
+| `injectOrdering`      | `OrderingModel<M>`                       | —              | Ordenação fixa injetada automaticamente na query.                                                                                   |
 | `injectPagination`    | `PaginationModel<M>`                     | —              | Paginação fixa injetada automaticamente na query.                                                                                   |
 | `query`               | `{ value: string; modifying?: boolean }` | —              | Transforma o método em um **Query Method** (SQL bruto). Ignora todas as outras opções acima — veja [Query Methods](#query-methods). |
 
@@ -1176,7 +1176,7 @@ await userRepository.prisma.$transaction(async (tx) => {
 | `modifying`   | `boolean` | `false` | Quando `true`, executa via `$executeRawUnsafe` e o método sempre resolve para `number`. Quando `false`, executa via `$queryRawUnsafe` e o método resolve para `TReturn` (`any` por padrão, inferível via generic na chamada). |
 
 > [!NOTE]
-> Diferente dos demais métodos dinâmicos, Query Methods **ignoram completamente** `selectModels`, `requiredWhere`, `pushWhere`, `whereType`, `injectOrdenation`, `injectPagination` e `proxyTo` — nada disso se aplica, já que não há parsing de nome nem montagem de `where`/`select` pelo VSRepository. Nomes de métodos livres (fora dos padrões de `findBy`, `updateBy`, etc.) também **não** exigem `proxyTo`.
+> Diferente dos demais métodos dinâmicos, Query Methods **ignoram completamente** `selectModels`, `requiredWhere`, `pushWhere`, `whereType`, `injectOrdering`, `injectPagination` e `proxyTo` — nada disso se aplica, já que não há parsing de nome nem montagem de `where`/`select` pelo VSRepository. Nomes de métodos livres (fora dos padrões de `findBy`, `updateBy`, etc.) também **não** exigem `proxyTo`.
 
 A mesma funcionalidade está disponível na abordagem baseada em classes através do decorator `@QueryMethod` — veja o [README-DynamicRepo.pt-BR.md](./README-DynamicRepo.pt-BR.md#o-decorator-querymethod).
 
@@ -1388,7 +1388,7 @@ import type {
   IncludeModel,
   IncludeModels,
   WhereModel,
-  OrdenationModel,
+  OrderingModel,
   PaginationModel,
   ModelUpsertInput,
   PrismaModelInputs,
@@ -1471,7 +1471,7 @@ setupVSRepo<TPayload, TTableName>()({
   defaultSelectModel?: keyof SM;                  // Select aplicado por padrão
   includeModels?: IncludeModels<M>;               // Projeções de dados nomeadas (include) — sem padrão, apenas na chamada
   requiredWhere?: WhereModel<M>;                  // Filtros sempre aplicados
-  defaultOrdenation?: OrdenationModel<M>;         // Ordenação padrão para queries sem Ordered/injectOrdenation
+  defaultOrdering?: OrderingModel<M>;             // Ordenação padrão para queries sem Ordered/injectOrdering
   relations?: RepositoryRelations<T>;             // Configuração de relações
   methods?: Record<string, MethodConfig<M, SM>>;  // Métodos dinâmicos
 });
@@ -1593,7 +1593,7 @@ Para reportar problemas ou sugerir novas funcionalidades, abra uma **Issue**.
 
 **`softRemovekName` lança um erro no build** — O campo informado deve ser do tipo `DateTime` no schema do Prisma. Tipos como `Boolean` ou `String` não são aceitos.
 
-**`defaultOrdenation` não está sendo aplicado** — Verifique se o método usa o sufixo `Ordered`, `OrderedAndPaginated` ou `PaginatedAndOrdered`, e se tem `injectOrdenation` configurado. Ambos têm prioridade sobre a ordenação padrão.
+**`defaultOrdering` não está sendo aplicado** — Verifique se o método usa o sufixo `Ordered`, `OrderedAndPaginated` ou `PaginatedAndOrdered`, e se tem `injectOrdering` configurado. Ambos têm prioridade sobre a ordenação padrão.
 
 **Sufixo `Distinct` não é reconhecido** — `Distinct` só é resolvido em prefixos de leitura (`findMany`, `findFirst`, `findBy`, `existsBy`, etc). Em métodos como `count`, `createMany`, `updateMany` ou `deleteMany` o sufixo é ignorado.
 

--- a/examples/dynamic-repositories.ts
+++ b/examples/dynamic-repositories.ts
@@ -17,7 +17,7 @@ import {
     DynamicRepository,
     DynamicMethod,
     DynamicMethodOptions,
-    OrdenationModel,
+    OrderingModel,
     PaginationModel,
     QueryMethod,
     QueryMethodArg,
@@ -157,10 +157,10 @@ class UserRepository extends DynamicRepository<
     @DynamicMethod<"User">({ proxyTo: "findBy", pushWhere: { userType: UserType.ADMIN } })
     declare findAdmins: (options?: DynamicMethodOptions<"User">) => Promise<User[]>;
 
-    // * "injectOrdenation" injects a fixed ordering automatically, without needing an "Ordered" suffix or an
+    // * "injectOrdering" injects a fixed ordering automatically, without needing an "Ordered" suffix or an
     // * extra "order" parameter — here every call is automatically ordered by the address's state and city
     @DynamicMethod<"User">({
-        injectOrdenation: [{ address: { state: "asc" } }, { address: { city: "asc" } }],
+        injectOrdering: [{ address: { state: "asc" } }, { address: { city: "asc" } }],
     })
     declare findByAddressWithCountry: (
         country: string,
@@ -172,7 +172,7 @@ class UserRepository extends DynamicRepository<
     @DynamicMethod()
     declare findByNameContainsInsensitiveOrderedAndPaginated: (
         name: string,
-        order: OrdenationModel<"User">,
+        order: OrderingModel<"User">,
         pagination: PaginationModel<"User">,
         options?: DynamicMethodOptions<"User">,
     ) => Promise<User[]>;

--- a/examples/repositories.ts
+++ b/examples/repositories.ts
@@ -159,7 +159,7 @@ const userVSRepo = setupVSRepo<User, "User">()({
         findByAddressWithCountry: {
             map: true,
             // * Here we inject a fixed ordering for this method, results will be automatically ordered by state and by city
-            injectOrdenation: [{ address: { state: "asc" } }, { address: { city: "asc" } }],
+            injectOrdering: [{ address: { state: "asc" } }, { address: { city: "asc" } }],
         },
 
         // * We can also search for users without an address

--- a/generated/vsrepo/DynamicRepository.types.d.ts
+++ b/generated/vsrepo/DynamicRepository.types.d.ts
@@ -16,7 +16,7 @@ import {
     ExtractNestedUpdateInput,
     IncludeModel,
     ModelUpsertInput,
-    OrdenationModel,
+    OrderingModel,
     PaginationModel,
     PaginationOptions,
     PrismaModelInputs,
@@ -232,12 +232,23 @@ export interface DynamicRepositoryConstructorConfig<T, U extends PrismaModelName
 
     /**
      * Default ordering automatically injected into all queries that accept `orderBy`,
-     * unless the method already has `injectOrdenation` configured or uses the `Ordered` suffix.
+     * unless the method already has `injectOrdering` configured or uses the `Ordered` suffix.
      *
      * Useful for ensuring a consistent sort order across the repository without repeating
      * the `order` argument on every call.
      */
-    defaultOrdenation?: OrdenationModel<U>;
+    defaultOrdering?: OrderingModel<U>;
+
+    /**
+     * Default ordering automatically injected into all queries that accept `orderBy`,
+     * unless the method already has `injectOrdering` configured or uses the `Ordered` suffix.
+     *
+     * Useful for ensuring a consistent sort order across the repository without repeating
+     * the `order` argument on every call.
+     *
+     * @deprecated Use `defaultOrdering` instead.
+     */
+    defaultOrdenation?: OrderingModel<U>;
 
     /**
      * Configures automatic relation management.
@@ -344,10 +355,10 @@ export declare abstract class DynamicRepository<
             pagination?: PaginationOptions;
             /**
              * Ordering to apply to the query.
-             * When omitted and `defaultOrdenation` is configured on the repository,
+             * When omitted and `defaultOrdering` is configured on the repository,
              * the default ordering is applied automatically.
              */
-            order?: OrdenationModel<UName>;
+            order?: OrderingModel<UName>;
         },
     ): Promise<TEntity[]>;
 
@@ -393,7 +404,13 @@ export type DynamicMethodConfig<M extends PrismaModelName = PrismaModelName> = {
     fbMode?: "one" | "list";
 
     /** Injects a fixed ordering automatically into the query. */
-    injectOrdenation?: OrdenationModel<M>;
+    injectOrdering?: OrderingModel<M>;
+
+    /**
+     * Injects a fixed ordering automatically into the query.
+     * @deprecated Use `injectOrdering` instead.
+     */
+    injectOrdenation?: OrderingModel<M>;
 
     /** Injects a fixed pagination automatically into the query. */
     injectPagination?: PaginationModel<M>;
@@ -414,7 +431,7 @@ export type DynamicMethodConfig<M extends PrismaModelName = PrismaModelName> = {
  *     `@DynamicMethod()`
  *     declare findOneByEmail: (email: string) => Promise<User | null>;
  *
- *     @DynamicMethod<"User">({ injectOrdenation: { createdAt: "desc" } })
+ *     @DynamicMethod<"User">({ injectOrdering: { createdAt: "desc" } })
  *     declare findByAge: (email: number) => Promise<User[]>;
  * }
  * ```

--- a/generated/vsrepo/VSRepository.types.d.ts
+++ b/generated/vsrepo/VSRepository.types.d.ts
@@ -417,7 +417,7 @@ type ExtractIncludeModels<Config> = Config extends { includeModels: infer IM } ?
 type ExtractDefaultSelect<Config> = Config extends { defaultSelectModel: infer D } ? D : never;
 type ExtractRelations<Config> = Config extends { relations: infer R } ? (R extends object ? R : {}) : {};
 type ExtractSoftRemovekName<Config> = Config extends { softRemovekName: infer S } ? S : never;
-type ExtractDefaultOrdenation<Config> = Config extends { defaultOrdenation: infer O } ? O : never;
+type ExtractDefaultOrdering<Config> = Config extends { defaultOrdering: infer O } ? O : Config extends { defaultOrdenation: infer O } ? O : never;
 
 type AggregateMethod<M extends PrismaModelName> = <A extends Prisma.TypeMap['model'][M]['operations']['aggregate']['args']>(
     prismaArgs: A, 
@@ -537,7 +537,13 @@ export type CursorModel<M extends PrismaModelName> = PrismaModelInputs<M>['curso
 /**
  * Type of the `orderBy` object of a Prisma model.
  */
-export type OrdenationModel<M extends PrismaModelName> = PrismaModelInputs<M>['orderByInput'];
+export type OrderingModel<M extends PrismaModelName> = PrismaModelInputs<M>['orderByInput'];
+
+/**
+ * Type of the `orderBy` object of a Prisma model.
+ * @deprecated Use `OrderingModel` instead.
+ */
+export type OrdenationModel<M extends PrismaModelName> = OrderingModel<M>;
 
 /**
  * Pagination options with typed cursor for a Prisma model.
@@ -571,7 +577,12 @@ export type MethodConfig<M extends PrismaModelName, SelectModels = any> = {
      */
     readonly fbMode?: 'one' | 'list';
     /** Injects a fixed ordering automatically into the query. */
-    readonly injectOrdenation?: OrdenationModel<M>;
+    readonly injectOrdering?: OrderingModel<M>;
+    /**
+     * Injects a fixed ordering automatically into the query.
+     * @deprecated Use `injectOrdering` instead.
+     */
+    readonly injectOrdenation?: OrderingModel<M>;
     /** Injects a fixed pagination automatically into the query. */
     readonly injectPagination?: PaginationModel<M>;
     /**
@@ -822,7 +833,7 @@ type _Inc<Config> = ExtractIncludeModels<Config>;
 type _Def<Config> = ExtractDefaultSelect<Config>;
 type _Rel<Config> = ExtractRelations<Config>;
 type _Soft<Config> = ExtractSoftRemovekName<Config>;
-type _DOrd<Config> = ExtractDefaultOrdenation<Config>;
+type _DOrd<Config> = ExtractDefaultOrdering<Config>;
 
 // ─── refactored mapped type — optimized for the TS compiler ──────────────────
 
@@ -837,7 +848,7 @@ type AllBaseMethods<
     TRelations = _Rel<Config>,
     TSoftKey  = _Soft<Config>,
     I         = PrismaModelInputs<M>,
-    TDefaultOrdenation = _DOrd<Config>,
+    TDefaultOrdering = _DOrd<Config>,
     TIncludes = _Inc<Config>
 > = {
     /** Fetches a record by its primary key (PK). */
@@ -894,7 +905,7 @@ type AllBaseMethods<
             pagination?: PaginationOptions<I extends { cursorInput: infer Curs } ? Curs : unknown>;
             /**
              * Ordering to apply to the query.
-             * When omitted and `defaultOrdenation` is configured on the repository,
+             * When omitted and `defaultOrdering` is configured on the repository,
              * the default ordering is applied automatically.
              */
             order?: I extends { orderByInput: infer OB } ? OB : OrderOptions;
@@ -935,10 +946,10 @@ type InjectedBaseMethods<
     TRelations = _Rel<Config>,
     TSoftKey  = _Soft<Config>,
     I         = PrismaModelInputs<M>,
-    TDefaultOrdenation = _DOrd<Config>,
+    TDefaultOrdering = _DOrd<Config>,
     TIncludes = _Inc<Config>
 > = Pick<
-    AllBaseMethods<T, M, Config, C, TSelects, TDefault, TPk, TRelations, TSoftKey, I, TDefaultOrdenation, TIncludes>,
+    AllBaseMethods<T, M, Config, C, TSelects, TDefault, TPk, TRelations, TSoftKey, I, TDefaultOrdering, TIncludes>,
     | (C extends { baseMethods: { get:          { active: false } } } ? never : 'get')
     | (C extends { baseMethods: { getOrThrow:   { active: false } } } ? never : 'getOrThrow')
     | (C extends { baseMethods: { getList:      { active: false } } } ? never : 'getList')
@@ -1042,7 +1053,9 @@ export type RepoConfig<T, M extends PrismaModelName, SM extends Record<string, A
     defaultSelectModel?: Extract<keyof SM, string>;
     includeModels?: IncludeModels<M>;
     requiredWhere?: WhereModel<M>;
-    defaultOrdenation?: OrdenationModel<M>;
+    defaultOrdering?: OrderingModel<M>;
+    /** @deprecated Use `defaultOrdering` instead. */
+    defaultOrdenation?: OrderingModel<M>;
     relations?: RepositoryRelations<T>;
     methods?: Record<string, MethodConfig<M, SM>>;
 };
@@ -1140,12 +1153,23 @@ export type ValidateRepoConfig<T extends object, M extends PrismaModelName, Conf
 
     /**
      * Default ordering automatically injected into all queries that accept `orderBy`,
-     * unless the method already has `injectOrdenation` configured or uses the `Ordered` suffix.
+     * unless the method already has `injectOrdering` configured or uses the `Ordered` suffix.
      *
      * Useful for ensuring a consistent sort order across the repository without repeating
      * the `order` argument on every call.
      */
-    defaultOrdenation?: OrdenationModel<M>;
+    defaultOrdering?: OrderingModel<M>;
+
+    /**
+     * Default ordering automatically injected into all queries that accept `orderBy`,
+     * unless the method already has `injectOrdering` configured or uses the `Ordered` suffix.
+     *
+     * Useful for ensuring a consistent sort order across the repository without repeating
+     * the `order` argument on every call.
+     *
+     * @deprecated Use `defaultOrdering` instead.
+     */
+    defaultOrdenation?: OrderingModel<M>;
 
     /**
      * Configures automatic relation management.

--- a/src/DynamicRepository.d.ts
+++ b/src/DynamicRepository.d.ts
@@ -8,7 +8,7 @@ import {
     ExtractNestedUpdateInput,
     IncludeModel,
     ModelUpsertInput,
-    OrdenationModel,
+    OrderingModel,
     PaginationModel,
     PaginationOptions,
     PrismaModelInputs,
@@ -224,12 +224,23 @@ export interface DynamicRepositoryConstructorConfig<T, U extends PrismaModelName
 
     /**
      * Default ordering automatically injected into all queries that accept `orderBy`,
-     * unless the method already has `injectOrdenation` configured or uses the `Ordered` suffix.
+     * unless the method already has `injectOrdering` configured or uses the `Ordered` suffix.
      *
      * Useful for ensuring a consistent sort order across the repository without repeating
      * the `order` argument on every call.
      */
-    defaultOrdenation?: OrdenationModel<U>;
+    defaultOrdering?: OrderingModel<U>;
+
+    /**
+     * Default ordering automatically injected into all queries that accept `orderBy`,
+     * unless the method already has `injectOrdering` configured or uses the `Ordered` suffix.
+     *
+     * Useful for ensuring a consistent sort order across the repository without repeating
+     * the `order` argument on every call.
+     *
+     * @deprecated Use `defaultOrdering` instead.
+     */
+    defaultOrdenation?: OrderingModel<U>;
 
     /**
      * Configures automatic relation management.
@@ -336,10 +347,10 @@ export declare abstract class DynamicRepository<
             pagination?: PaginationOptions;
             /**
              * Ordering to apply to the query.
-             * When omitted and `defaultOrdenation` is configured on the repository,
+             * When omitted and `defaultOrdering` is configured on the repository,
              * the default ordering is applied automatically.
              */
-            order?: OrdenationModel<UName>;
+            order?: OrderingModel<UName>;
         },
     ): Promise<TEntity[]>;
 
@@ -385,7 +396,13 @@ export type DynamicMethodConfig<M extends PrismaModelName = PrismaModelName> = {
     fbMode?: "one" | "list";
 
     /** Injects a fixed ordering automatically into the query. */
-    injectOrdenation?: OrdenationModel<M>;
+    injectOrdering?: OrderingModel<M>;
+
+    /**
+     * Injects a fixed ordering automatically into the query.
+     * @deprecated Use `injectOrdering` instead.
+     */
+    injectOrdenation?: OrderingModel<M>;
 
     /** Injects a fixed pagination automatically into the query. */
     injectPagination?: PaginationModel<M>;
@@ -406,7 +423,7 @@ export type DynamicMethodConfig<M extends PrismaModelName = PrismaModelName> = {
  *     `@DynamicMethod()`
  *     declare findOneByEmail: (email: string) => Promise<User | null>;
  *
- *     @DynamicMethod<"User">({ injectOrdenation: { createdAt: "desc" } })
+ *     @DynamicMethod<"User">({ injectOrdering: { createdAt: "desc" } })
  *     declare findByAge: (email: number) => Promise<User[]>;
  * }
  * ```

--- a/src/VSRepository.d.ts
+++ b/src/VSRepository.d.ts
@@ -409,7 +409,7 @@ type ExtractIncludeModels<Config> = Config extends { includeModels: infer IM } ?
 type ExtractDefaultSelect<Config> = Config extends { defaultSelectModel: infer D } ? D : never;
 type ExtractRelations<Config> = Config extends { relations: infer R } ? (R extends object ? R : {}) : {};
 type ExtractSoftRemovekName<Config> = Config extends { softRemovekName: infer S } ? S : never;
-type ExtractDefaultOrdenation<Config> = Config extends { defaultOrdenation: infer O } ? O : never;
+type ExtractDefaultOrdering<Config> = Config extends { defaultOrdering: infer O } ? O : Config extends { defaultOrdenation: infer O } ? O : never;
 
 type AggregateMethod<M extends PrismaModelName> = <A extends Prisma.TypeMap['model'][M]['operations']['aggregate']['args']>(
     prismaArgs: A, 
@@ -529,7 +529,13 @@ export type CursorModel<M extends PrismaModelName> = PrismaModelInputs<M>['curso
 /**
  * Type of the `orderBy` object of a Prisma model.
  */
-export type OrdenationModel<M extends PrismaModelName> = PrismaModelInputs<M>['orderByInput'];
+export type OrderingModel<M extends PrismaModelName> = PrismaModelInputs<M>['orderByInput'];
+
+/**
+ * Type of the `orderBy` object of a Prisma model.
+ * @deprecated Use `OrderingModel` instead.
+ */
+export type OrdenationModel<M extends PrismaModelName> = OrderingModel<M>;
 
 /**
  * Pagination options with typed cursor for a Prisma model.
@@ -563,7 +569,12 @@ export type MethodConfig<M extends PrismaModelName, SelectModels = any> = {
      */
     readonly fbMode?: 'one' | 'list';
     /** Injects a fixed ordering automatically into the query. */
-    readonly injectOrdenation?: OrdenationModel<M>;
+    readonly injectOrdering?: OrderingModel<M>;
+    /**
+     * Injects a fixed ordering automatically into the query.
+     * @deprecated Use `injectOrdering` instead.
+     */
+    readonly injectOrdenation?: OrderingModel<M>;
     /** Injects a fixed pagination automatically into the query. */
     readonly injectPagination?: PaginationModel<M>;
     /**
@@ -814,7 +825,7 @@ type _Inc<Config> = ExtractIncludeModels<Config>;
 type _Def<Config> = ExtractDefaultSelect<Config>;
 type _Rel<Config> = ExtractRelations<Config>;
 type _Soft<Config> = ExtractSoftRemovekName<Config>;
-type _DOrd<Config> = ExtractDefaultOrdenation<Config>;
+type _DOrd<Config> = ExtractDefaultOrdering<Config>;
 
 // ─── refactored mapped type — optimized for the TS compiler ──────────────────
 
@@ -829,7 +840,7 @@ type AllBaseMethods<
     TRelations = _Rel<Config>,
     TSoftKey  = _Soft<Config>,
     I         = PrismaModelInputs<M>,
-    TDefaultOrdenation = _DOrd<Config>,
+    TDefaultOrdering = _DOrd<Config>,
     TIncludes = _Inc<Config>
 > = {
     /** Fetches a record by its primary key (PK). */
@@ -886,7 +897,7 @@ type AllBaseMethods<
             pagination?: PaginationOptions<I extends { cursorInput: infer Curs } ? Curs : unknown>;
             /**
              * Ordering to apply to the query.
-             * When omitted and `defaultOrdenation` is configured on the repository,
+             * When omitted and `defaultOrdering` is configured on the repository,
              * the default ordering is applied automatically.
              */
             order?: I extends { orderByInput: infer OB } ? OB : OrderOptions;
@@ -927,10 +938,10 @@ type InjectedBaseMethods<
     TRelations = _Rel<Config>,
     TSoftKey  = _Soft<Config>,
     I         = PrismaModelInputs<M>,
-    TDefaultOrdenation = _DOrd<Config>,
+    TDefaultOrdering = _DOrd<Config>,
     TIncludes = _Inc<Config>
 > = Pick<
-    AllBaseMethods<T, M, Config, C, TSelects, TDefault, TPk, TRelations, TSoftKey, I, TDefaultOrdenation, TIncludes>,
+    AllBaseMethods<T, M, Config, C, TSelects, TDefault, TPk, TRelations, TSoftKey, I, TDefaultOrdering, TIncludes>,
     | (C extends { baseMethods: { get:          { active: false } } } ? never : 'get')
     | (C extends { baseMethods: { getOrThrow:   { active: false } } } ? never : 'getOrThrow')
     | (C extends { baseMethods: { getList:      { active: false } } } ? never : 'getList')
@@ -1034,7 +1045,9 @@ export type RepoConfig<T, M extends PrismaModelName, SM extends Record<string, A
     defaultSelectModel?: Extract<keyof SM, string>;
     includeModels?: IncludeModels<M>;
     requiredWhere?: WhereModel<M>;
-    defaultOrdenation?: OrdenationModel<M>;
+    defaultOrdering?: OrderingModel<M>;
+    /** @deprecated Use `defaultOrdering` instead. */
+    defaultOrdenation?: OrderingModel<M>;
     relations?: RepositoryRelations<T>;
     methods?: Record<string, MethodConfig<M, SM>>;
 };
@@ -1132,12 +1145,23 @@ export type ValidateRepoConfig<T extends object, M extends PrismaModelName, Conf
 
     /**
      * Default ordering automatically injected into all queries that accept `orderBy`,
-     * unless the method already has `injectOrdenation` configured or uses the `Ordered` suffix.
+     * unless the method already has `injectOrdering` configured or uses the `Ordered` suffix.
      *
      * Useful for ensuring a consistent sort order across the repository without repeating
      * the `order` argument on every call.
      */
-    defaultOrdenation?: OrdenationModel<M>;
+    defaultOrdering?: OrderingModel<M>;
+
+    /**
+     * Default ordering automatically injected into all queries that accept `orderBy`,
+     * unless the method already has `injectOrdering` configured or uses the `Ordered` suffix.
+     *
+     * Useful for ensuring a consistent sort order across the repository without repeating
+     * the `order` argument on every call.
+     *
+     * @deprecated Use `defaultOrdering` instead.
+     */
+    defaultOrdenation?: OrderingModel<M>;
 
     /**
      * Configures automatic relation management.

--- a/src/VSRepository.ts
+++ b/src/VSRepository.ts
@@ -33,7 +33,7 @@ export class VSRepository {
     requiredWhere?: object;
     relations?: Record<string, Relation>;
     methods?: Record<string | symbol, Method>;
-    defaultOrdenation?: object | object[];
+    defaultOrdering?: object | object[];
 
     constructor(config: unknown) {
         const validatedConfig = validateConstructorConfig(config);
@@ -48,7 +48,7 @@ export class VSRepository {
         this.relations = validatedConfig.relations;
         this.requiredWhere = validatedConfig.requiredWhere;
         this.methods = validatedConfig.methods;
-        this.defaultOrdenation = validatedConfig.defaultOrdenation;
+        this.defaultOrdering = validatedConfig.defaultOrdering;
     }
 
     extend(extensionFunc: unknown) {
@@ -206,10 +206,10 @@ export class VSRepository {
                             pushWhere: dynamicMethodWhereOps.pushWhere,
                             withoutSelect: dynamicMethodInfo.ignoreSelect,
                             skipDuplicates: dynamicMethodCustomization.skipDuplicates,
-                            ordenation:
+                            ordering:
                                 dynamicMethodCustomization.orderPosition !== undefined
                                     ? args.at(dynamicMethodCustomization.orderPosition)
-                                    : dynamicMethodCustomization.injectOrdenation,
+                                    : dynamicMethodCustomization.injectOrdering,
                             pagination:
                                 dynamicMethodCustomization.paginationPosition !== undefined
                                     ? args.at(dynamicMethodCustomization.paginationPosition)
@@ -226,7 +226,7 @@ export class VSRepository {
                                 dynamicMethodInfo.updateIndex !== undefined
                                     ? args.at(dynamicMethodInfo.updateIndex)
                                     : undefined,
-                            withOrdenationAndPagination:
+                            withOrderingAndPagination:
                                 !dynamicMethodInfo.ignoreOrderByAndPagination,
                             distinctKeys: dynamicMethodCustomization.distinctKeys,
                         };

--- a/src/internal/decorators/dynamic-method.decorator.ts
+++ b/src/internal/decorators/dynamic-method.decorator.ts
@@ -16,7 +16,7 @@ export function DynamicMethod(config?: unknown): PropertyDecorator {
                 validatedConfig?.whereType,
                 validatedConfig?.pushWhere,
                 validatedConfig?.fbMode,
-                validatedConfig?.injectOrdenation,
+                validatedConfig?.injectOrdering,
                 validatedConfig?.injectPagination,
             ),
         );

--- a/src/internal/decorators/types/dynamic-method-config.type.ts
+++ b/src/internal/decorators/types/dynamic-method-config.type.ts
@@ -4,7 +4,7 @@ export interface DynamicMethodConfig {
     whereType?: "overwrite" | "extending";
     pushWhere?: object;
     fbMode?: "one" | "list";
-    injectOrdenation?: object;
+    injectOrdering?: object;
     injectPagination?: object;
     query?: {
         value: string;

--- a/src/internal/entities/dynamic-method-metadata.entity.ts
+++ b/src/internal/entities/dynamic-method-metadata.entity.ts
@@ -6,7 +6,7 @@ export class DynamicMethodMetadata {
         public readonly whereType?: "overwrite" | "extending",
         public readonly pushWhere?: object,
         public readonly fbMode?: "one" | "list",
-        public readonly injectOrdenation?: object,
+        public readonly injectOrdering?: object,
         public readonly injectPagination?: object,
         public readonly query?: { value: string; modifying: boolean },
     ) {}

--- a/src/internal/resolvers/base-methods.resolve.ts
+++ b/src/internal/resolvers/base-methods.resolve.ts
@@ -122,8 +122,8 @@ export function resolveBaseMethods(instance: RepositoryBuildInstance, config: Bu
                 baseConfig: baseMethods.getAll,
                 options: restOptions,
                 pagination,
-                ordenation: order,
-                withOrdenationAndPagination: true,
+                ordering: order,
+                withOrderingAndPagination: true,
             });
 
             const start = showWorking

--- a/src/internal/resolvers/dbAndPrismaArgs.resolve.ts
+++ b/src/internal/resolvers/dbAndPrismaArgs.resolve.ts
@@ -20,11 +20,11 @@ export function resolveDbAndPrismaArgs(data: ResolveDbAndPrismaArgsData) {
         alreadyValidatedOptions,
         specificWhere,
         pushWhere,
-        ordenation,
+        ordering,
         pagination,
         skipDuplicates,
         forceSeeMode,
-        withOrdenationAndPagination,
+        withOrderingAndPagination,
         distinctKeys,
     } = data;
 
@@ -79,9 +79,9 @@ export function resolveDbAndPrismaArgs(data: ResolveDbAndPrismaArgsData) {
         prismaArgs.update = updatePayload;
     }
 
-    if (withOrdenationAndPagination) {
-        if (instance.defaultOrdenation || ordenation) {
-            prismaArgs.orderBy = ordenation ?? instance.defaultOrdenation;
+    if (withOrderingAndPagination) {
+        if (instance.defaultOrdering || ordering) {
+            prismaArgs.orderBy = ordering ?? instance.defaultOrdering;
         }
 
         if (pagination) {

--- a/src/internal/resolvers/dynamic-method-customization.resolve.ts
+++ b/src/internal/resolvers/dynamic-method-customization.resolve.ts
@@ -21,8 +21,8 @@ export function resolveDynamicMethodCustomization(
     }
 
     if (!dynamicMethodInfo.ignoreOrderByAndPagination) {
-        dynamicMethodCustomization.injectOrdenation =
-            instance.methods?.[originalKey]?.injectOrdenation;
+        dynamicMethodCustomization.injectOrdering =
+            instance.methods?.[originalKey]?.injectOrdering;
         dynamicMethodCustomization.injectPagination =
             instance.methods?.[originalKey]?.injectPagination;
 

--- a/src/internal/resolvers/types/dynamic-method-customization.type.ts
+++ b/src/internal/resolvers/types/dynamic-method-customization.type.ts
@@ -4,7 +4,7 @@ export interface DynamicMethodCustomization {
     skipDuplicates?: boolean;
     orderPosition?: number;
     paginationPosition?: number;
-    injectOrdenation?: object | object[];
+    injectOrdering?: object | object[];
     injectPagination?: Pagination;
     distinctKeys?: string[];
 }

--- a/src/internal/resolvers/types/resolve-db-and-prisma-args-data.type.ts
+++ b/src/internal/resolvers/types/resolve-db-and-prisma-args-data.type.ts
@@ -18,9 +18,9 @@ export interface ResolveDbAndPrismaArgsData {
     updatePayload?: object;
     pushWhere?: object;
     pagination?: Pagination;
-    ordenation?: object | object[];
+    ordering?: object | object[];
     skipDuplicates?: boolean;
     forceSeeMode?: SeeMode;
-    withOrdenationAndPagination?: boolean;
+    withOrderingAndPagination?: boolean;
     distinctKeys?: string[];
 }

--- a/src/internal/utils/schemas.util.ts
+++ b/src/internal/utils/schemas.util.ts
@@ -9,14 +9,20 @@ export const queryOptionsSchema = z.strictObject({
     modifying: booleanSchema.default(false),
 });
 
-export const methodSchema = z.strictObject({
-    map: booleanSchema,
-    selectModel: stringSchema.or(z.literal(false)).optional(),
-    whereType: z.enum(["overwrite", "extending"]).optional(),
-    proxyTo: stringSchema.optional(),
-    pushWhere: objectSchema.optional(),
-    fbMode: z.enum(["one", "list"]).optional(),
-    injectOrdenation: objectSchema.or(z.array(objectSchema)).optional(),
-    injectPagination: objectSchema.optional(),
-    query: queryOptionsSchema.optional(),
-});
+export const methodSchema = z
+    .strictObject({
+        map: booleanSchema,
+        selectModel: stringSchema.or(z.literal(false)).optional(),
+        whereType: z.enum(["overwrite", "extending"]).optional(),
+        proxyTo: stringSchema.optional(),
+        pushWhere: objectSchema.optional(),
+        fbMode: z.enum(["one", "list"]).optional(),
+        injectOrdenation: objectSchema.or(z.array(objectSchema)).optional(),
+        injectOrdering: objectSchema.or(z.array(objectSchema)).optional(),
+        injectPagination: objectSchema.optional(),
+        query: queryOptionsSchema.optional(),
+    })
+    .transform(({ injectOrdenation, injectOrdering, ...value }) => ({
+        ...value,
+        injectOrdering: injectOrdering ?? injectOrdenation,
+    }));

--- a/src/internal/validation/constructor-config.validate.ts
+++ b/src/internal/validation/constructor-config.validate.ts
@@ -25,13 +25,9 @@ export function validateConstructorConfig(config: unknown): ConstructorConfig {
                     }),
                 )
                 .optional(),
-            methods: z
-                .record(
-                    stringSchema,
-                    methodSchema,
-                )
-                .optional(),
+            methods: z.record(stringSchema, methodSchema).optional(),
             defaultOrdenation: objectSchema.or(z.array(objectSchema)).optional(),
+            defaultOrdering: objectSchema.or(z.array(objectSchema)).optional(),
         })
         .superRefine((config, ctx) => {
             if (config.defaultSelectModel && !config.selectModels?.[config.defaultSelectModel]) {
@@ -53,7 +49,11 @@ export function validateConstructorConfig(config: unknown): ConstructorConfig {
                     }
                 }
             }
-        });
+        })
+        .transform(({ defaultOrdenation, defaultOrdering, ...value }) => ({
+            ...value,
+            defaultOrdering: defaultOrdering ?? defaultOrdenation,
+        }));
 
     const configParsed = configSchema.safeParse(config);
 

--- a/src/internal/validation/types/constructor-config.type.ts
+++ b/src/internal/validation/types/constructor-config.type.ts
@@ -11,5 +11,5 @@ export interface ConstructorConfig {
     requiredWhere?: object;
     relations?: Record<string, Relation>;
     methods?: Record<string, Method>;
-    defaultOrdenation?: object | object[];
+    defaultOrdering?: object | object[];
 }

--- a/src/internal/validation/types/method.type.ts
+++ b/src/internal/validation/types/method.type.ts
@@ -7,7 +7,7 @@ export interface Method {
     proxyTo?: string;
     pushWhere?: object;
     fbMode?: "one" | "list";
-    injectOrdenation?: object | object[];
+    injectOrdering?: object | object[];
     injectPagination?: Pagination;
     query?: {
         value: string;

--- a/test/implementation/class-based-api.test.ts
+++ b/test/implementation/class-based-api.test.ts
@@ -28,7 +28,7 @@ class UserRepository extends DynamicRepository<
             tableName: "user",
             pkName: "id",
             requiredWhere: { active: true },
-            defaultOrdenation: [{ createdAt: "desc" }],
+            defaultOrdering: [{ createdAt: "desc" }],
             relations: {
                 address: { mode: "oto", pk: "id", restriction: "set" },
                 products: { mode: "otm", pk: "id", restriction: "add" },
@@ -103,7 +103,7 @@ class UserRepository extends DynamicRepository<
     declare findAdmins: (options?: DynamicMethodOptions<"User">) => Promise<User[]>;
 
     @DynamicMethod<"User">({
-        injectOrdenation: [{ address: { state: "asc" } }, { address: { city: "asc" } }],
+        injectOrdering: [{ address: { state: "asc" } }, { address: { city: "asc" } }],
     })
     declare findByAddressWithCountry: (
         country: string,

--- a/test/implementation/functional-api.test.ts
+++ b/test/implementation/functional-api.test.ts
@@ -86,7 +86,7 @@ const userVSRepo = setupVSRepo<User, "User">()({
         },
     },
 
-    defaultOrdenation: [{ createdAt: "desc" }],
+    defaultOrdering: [{ createdAt: "desc" }],
 
     methods: {
         findByUserType: { map: true },
@@ -124,7 +124,7 @@ const userVSRepo = setupVSRepo<User, "User">()({
         findByAddressWithCountry: {
             map: true,
 
-            injectOrdenation: [{ address: { state: "asc" } }, { address: { city: "asc" } }],
+            injectOrdering: [{ address: { state: "asc" } }, { address: { city: "asc" } }],
         },
 
         findByAddressWithout: { map: true },


### PR DESCRIPTION
This pull request updates the documentation to consistently use the term `Ordering` instead of `Ordenation` for all ordering-related configuration options and types. This affects both English and Portuguese documentation files, improving clarity and aligning terminology with standard naming conventions.

**Documentation terminology updates:**

*English documentation (`README.md`, `README-DynamicRepo.md`):*
- Renamed all instances of `OrdenationModel`, `injectOrdenation`, and `defaultOrdenation` to `OrderingModel`, `injectOrdering`, and `defaultOrdering` respectively throughout the documentation, code examples, and type definitions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L664-R672) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L686-R702) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1089-R1089) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1179-R1179) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1391-R1391) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1474-R1474) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1596-R1596) [[9]](diffhunk://#diff-8f970d81f30383d68a006307eeb9ce5011947ff09760e0b63ecc83c5899953baL148-R148) [[10]](diffhunk://#diff-8f970d81f30383d68a006307eeb9ce5011947ff09760e0b63ecc83c5899953baL158-R158) [[11]](diffhunk://#diff-8f970d81f30383d68a006307eeb9ce5011947ff09760e0b63ecc83c5899953baL198-R198) [[12]](diffhunk://#diff-8f970d81f30383d68a006307eeb9ce5011947ff09760e0b63ecc83c5899953baL228-R228) [[13]](diffhunk://#diff-8f970d81f30383d68a006307eeb9ce5011947ff09760e0b63ecc83c5899953baL562-R562)

*Portuguese documentation (`README.pt-BR.md`, `README-DynamicRepo.pt-BR.md`):*
- Updated all references from `OrdenationModel`, `injectOrdenation`, and `defaultOrdenation` to `OrderingModel`, `injectOrdering`, and `defaultOrdering` for consistency with the English documentation and code. [[1]](diffhunk://#diff-1429a5f8afc794182301e346da630d8884661cc020c677dbdbd2fac7dfcd16c2L42-R42) [[2]](diffhunk://#diff-1429a5f8afc794182301e346da630d8884661cc020c677dbdbd2fac7dfcd16c2L664-R672) [[3]](diffhunk://#diff-1429a5f8afc794182301e346da630d8884661cc020c677dbdbd2fac7dfcd16c2L686-R702) [[4]](diffhunk://#diff-c77292e6b155321cbaff9c2f68b2cabb2d1335c1fc28b235d181a7763a213ac1L148-R148) [[5]](diffhunk://#diff-c77292e6b155321cbaff9c2f68b2cabb2d1335c1fc28b235d181a7763a213ac1L158-R158) [[6]](diffhunk://#diff-c77292e6b155321cbaff9c2f68b2cabb2d1335c1fc28b235d181a7763a213ac1L198-R198) [[7]](diffhunk://#diff-c77292e6b155321cbaff9c2f68b2cabb2d1335c1fc28b235d181a7763a213ac1L228-R228) [[8]](diffhunk://#diff-c77292e6b155321cbaff9c2f68b2cabb2d1335c1fc28b235d181a7763a213ac1L562-R562)

These changes ensure that the documentation uses clear and consistent terminology, reducing confusion for users and aligning with Prisma's conventions. No code logic was changed—only documentation and type names were updated.