### PR TITLE
feat: copia os readmes para uma pasta 'docs' na pasta generada em vsr…

### DIFF
--- a/generated/vsrepo/docs/README-DynamicRepo.md
+++ b/generated/vsrepo/docs/README-DynamicRepo.md
@@ -1,0 +1,625 @@
+# DynamicRepository (Class-based approach)
+
+🇺🇸 You're reading the English version. [🇧🇷 Ler em português](./README-DynamicRepo.pt-BR.md)
+
+VSRepository offers two ways to create repositories: the functional `setupVSRepo` approach and the OOP `DynamicRepository` class-based approach. This document covers the class-based approach using `DynamicRepository` and the `@DynamicMethod` decorator.
+
+> For the functional approach, see the main [README.md](./README.md).
+
+## Table of contents
+
+- [When to use DynamicRepository](#when-to-use-dynamicrepository)
+- [Requirements](#requirements)
+- [Creating a class](#creating-a-class)
+- [The @DynamicMethod decorator](#the-dynamicmethod-decorator)
+- [Decorator config options](#decorator-config-options)
+- [The @QueryMethod decorator](#the-querymethod-decorator)
+- [Base methods](#base-methods)
+- [Working with relations](#working-with-relations)
+- [Transactions](#transactions)
+- [Working with includes](#working-with-includes)
+- [DynamicMethodOptions](#dynamicmethodoptions)
+- [NestJS integration](#nestjs-integration)
+- [API Reference](#api-reference)
+- [Differences from setupVSRepo](#differences-from-setupvsrepo)
+
+---
+
+## When to use DynamicRepository
+
+Use `DynamicRepository` when you prefer an **OOP style with decorators** over the functional `setupVSRepo` approach. Key characteristics:
+
+- Methods are defined as `declare` fields with `@DynamicMethod()` decorators
+- The repository is a class you can extend and inject via dependency injection
+- `selectModels` and `includeModels` are **not supported** (use raw `select`/`include` via `DynamicMethodOptions` instead)
+- Base methods are always active (no `active` toggle per method)
+- The repository is built automatically in the constructor (no explicit `.build()` call)
+
+---
+
+## Requirements
+
+`DynamicRepository` relies on TypeScript's legacy decorators, so your project's `tsconfig.json` must have:
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}
+```
+
+`reflect-metadata` is already a dependency of `vsrepo` and is imported internally — you don't need to import it yourself.
+
+Without `experimentalDecorators: true`, `@DynamicMethod()` will fail to compile (or silently fail to register the method at runtime, depending on your build tool).
+
+---
+
+## Creating a class
+
+Extend `DynamicRepository` with four generic parameters:
+
+```typescript
+import {
+    DynamicRepository,
+    DynamicMethod,
+    DynamicMethodOptions,
+    PaginationModel,
+} from "../../generated/vsrepo";
+import type { Prisma } from "../../generated/prisma/client";
+import { PrismaClient } from "../../generated/prisma/client";
+
+type User = Prisma.UserGetPayload<{
+    include: { address: true; posts: true };
+}>;
+
+class UserRepository extends DynamicRepository<
+    User,        // Entity type (with relations included)
+    "User",      // Prisma model name
+    string,      // Primary key type
+    { address: true; posts: true }  // Which fields are relations (flags)
+> {
+    constructor(prisma: PrismaClient) {
+        super(prisma, {
+            tableName: "user",
+            pkName: "id",
+            relations: {
+                address: { mode: "oto", pk: "id", restriction: "set" },
+                posts: { mode: "otm", pk: "id", restriction: "add" },
+            },
+            requiredWhere: { active: true },
+            build: {
+                showWorking: false,
+                baseMethods: {
+                    save: { ignoreRequiredWhere: true },
+                },
+            },
+        });
+    }
+}
+```
+
+**Generic parameters:**
+
+| Parameter                 | Description                                                                                                                                                           |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TEntity`                 | The full entity type, including any relations you want available                                                                                                      |
+| `UName`                   | The Prisma model name as a string literal (capitalized, e.g. `"User"`)                                                                                                |
+| `VPKType`                 | The type of the primary key (`string`, `number`, etc.)                                                                                                                |
+| `WRelations` *(optional)* | An object flags indicating which fields are relations (e.g. `{ address: true }`). Only needed if you plan to configure the repository's relations — omit it otherwise |
+
+---
+
+## The @DynamicMethod decorator
+
+Declare dynamic methods as class fields using `declare` and decorate them with `@DynamicMethod()`:
+
+```typescript
+class UserRepository extends DynamicRepository<User, "User", string> {
+    // Simple dynamic method - name determines behavior
+    @DynamicMethod()
+    declare findByEmail: (email: string) => Promise<User | null>;
+
+    // With decorator config
+    @DynamicMethod<"User">({ proxyTo: "findMany", pushWhere: { active: false } })
+    declare findDisabled: () => Promise<User[]>;
+
+    // Proxy to another method
+    @DynamicMethod<"User">({ proxyTo: "findOneByEmail", whereType: "overwrite" })
+    declare findInternalByEmail: (email: string) => Promise<User | null>;
+}
+```
+
+The method **name** determines the behavior (same rules as the functional approach). The decorator config object adjusts that behavior.
+
+> **Important:** Always use `declare` (not a regular property) for decorated fields. The decorator provides runtime metadata; the `declare` keyword tells TypeScript the property exists without emitting initialization code.
+
+---
+
+## Decorator config options
+
+The `@DynamicMethod<M>()` decorator accepts an optional config object:
+
+```typescript
+@DynamicMethod<"User">({
+    proxyTo: "findByEmail",                   // Delegate to another method pattern
+    whereType: "overwrite",                   // "extending" (default) or "overwrite"
+    pushWhere: { active: false },             // Extra where clause
+    injectOrdering: [{ name: "asc" }],        // Fixed ordering
+    injectPagination: { skip: 0, take: 10 },  // Fixed pagination
+})
+```
+
+| Option             | Type                         | Description                                                                                                       |
+| ------------------ | ---------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `proxyTo`          | `string`                     | Delegates to another valid method pattern (e.g. `"findOneByEmail"`)                                               |
+| `whereType`        | `"extending" \| "overwrite"` | `extending` combines with `requiredWhere`; `overwrite` ignores it                                                 |
+| `pushWhere`        | `WhereModel<M>`              | Extra `where` clause added on top of `requiredWhere`                                                              |
+| `injectOrdering`   | `OrderingModel<M>`           | Fixed ordering injected into the query                                                                            |
+| `injectPagination` | `PaginationModel<M>`         | Fixed pagination injected into the query                                                                          |
+| `fbMode`           | `"one" \| "list"`            | **Deprecated.** Only relevant for `findBy`-prefixed methods. Use `findOneBy` instead if you want a single result. |
+
+---
+
+## The @QueryMethod decorator
+
+`@QueryMethod` declares a **raw SQL query method** on a `declare` class field, completely bypassing the name-based method parser used by `@DynamicMethod`. It's useful for complex queries (heavy joins, CTEs, database-specific functions) that aren't practical to express through the standard prefixes/suffixes.
+
+Under the hood, the SQL is executed through Prisma using `$queryRawUnsafe` (reads) or `$executeRawUnsafe` (writes), and the values passed in `args` are injected as **positional parameters** (`$1`, `$2`, ...) — the same prepared-statement technique Prisma itself uses. Values are never concatenated into the SQL string, which is what actually prevents SQL injection.
+
+```typescript
+class UserRepository extends DynamicRepository<User, "User", string> {
+    // Read query method (non-modifying) — return type comes from the field declaration
+    @QueryMethod('SELECT * FROM "user" WHERE email = $1')
+    declare findByEmailRaw: (arg: QueryMethodArg<[email: string]>) => Promise<User[]>;
+
+    // Write query method — must always resolve to 'number'
+    @QueryMethod('UPDATE "user" SET active = true WHERE id = $1', { modifying: true })
+    declare activateUser: (arg: QueryMethodArg<[id: string]>) => Promise<number>;
+}
+
+const userRepository = new UserRepository(prisma, { tableName: "user", pkName: "id" });
+
+const users = await userRepository.findByEmailRaw({ args: ["joao@email.com"] });
+const affected = await userRepository.activateUser({ args: ["1"] });
+```
+
+> [!WARNING]
+> `$1`, `$2`, ... must always represent **values**, never column/table names or dynamic SQL fragments. Identifier names can't be passed as a positional parameter — if a method needs to vary those, build the SQL from a fixed, known set of options in your own code, never from untrusted input.
+
+Since `@QueryMethod` skips name parsing, there's no automatic type inference for the field: the method's parameter and return types come entirely from how you `declare` the field. Use `QueryMethodArg<T>` to type the single `{ args, db? }` argument the method receives.
+
+| Option                 | Type      | Default | Description                                                                                                                                  |
+| ---------------------- | --------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value` (1st argument) | `string`  | —       | **Required.** Raw SQL to execute. Use `$1`, `$2`, ... for the `args` placeholders.                                                           |
+| `options.modifying`    | `boolean` | `false` | When `true`, runs via `$executeRawUnsafe`; the field must be declared to return `Promise<number>`. When `false`, runs via `$queryRawUnsafe`. |
+
+> [!NOTE]
+> `@QueryMethod` ignores every other dynamic-method concept — `requiredWhere`, `pushWhere`, `whereType`, `selectModels`/`includeModels`, `injectOrdering`, `injectPagination`. None of it applies here.
+
+---
+
+## Base methods
+
+All `DynamicRepository` instances automatically include these methods:
+
+| Method                | Description                                                                                              |
+| --------------------- | -------------------------------------------------------------------------------------------------------- |
+| `get(pk)`             | Fetch a record by primary key                                                                            |
+| `getOrThrow(pk)`      | Fetch by PK, throws if not found                                                                         |
+| `getList(pks)`        | Fetch multiple records by PKs                                                                            |
+| `save(obj)`           | Create or upsert a record                                                                                |
+| `saveList(objs)`      | Batch save in an automatic transaction                                                                   |
+| `patch(pk, obj)`      | Partial update by PK                                                                                     |
+| `patchList(tuples)`   | Batch partial update via `[pk, obj]` tuples                                                              |
+| `merge(pk, obj)`      | Fetch and deep-merge in memory (does not persist)                                                        |
+| `remove(pk)`          | Delete a record by PK                                                                                    |
+| `removeList(pks)`     | Batch delete by PKs                                                                                      |
+| `getAll()`            | Fetch all records (respects `requiredWhere`). Accepts `pagination` and `order` in `options` — see below  |
+| `total()`             | Count all records                                                                                        |
+| `has(pk)`             | Check if a record exists                                                                                 |
+| `softRemove(pk)`      | Soft-delete (requires `softRemovekName` config)                                                          |
+| `softRemoveList(pks)` | Batch soft-delete                                                                                        |
+| `restore(pk)`         | Restore soft-deleted record                                                                              |
+| `restoreList(pks)`    | Batch restore                                                                                            |
+
+All methods accept an optional `options` argument based on `DynamicMethodOptions` (`db`, `see`, `include`, `select`), but a few methods narrow it further:
+
+- **`getAll`** additionally accepts `pagination?: PaginationOptions` and `order?: OrderingModel<UName>` (falls back to `defaultOrdering` when omitted).
+- **`saveList` / `patchList`** omit `include` and `select`, and `db` only accepts a `DbTransaction` (the return of `prisma.$transaction`) — not the plain Prisma client.
+- **`removeList`, `total`, `has`** omit `include` and `select`.
+- **`softRemove`, `restore`** omit `see` (soft-delete visibility doesn't apply to the record being changed).
+- **`softRemoveList`, `restoreList`** omit `see`, `include`, and `select`.
+
+```typescript
+// getAll with pagination and ordering
+const page = await userRepository.getAll({
+    pagination: { skip: 0, take: 20 },
+    order: { createdAt: "desc" },
+});
+```
+
+---
+
+## Working with relations
+
+Configure relations in the constructor so `save` and `patch` manage them automatically:
+
+```typescript
+class UserRepository extends DynamicRepository<
+    User, "User", string,
+    { address: true; posts: true }
+> {
+    constructor(prisma: PrismaClient) {
+        super(prisma, {
+            tableName: "user",
+            pkName: "id",
+            relations: {
+                address: { mode: "oto", pk: "id", restriction: "set" },
+                posts: { mode: "otm", pk: "id", restriction: "add" },
+            },
+        });
+    }
+}
+```
+
+The fourth generic parameter (`WRelations`) is **optional** — it's only needed when you're configuring relations for the repository. When provided, it must flag which fields are relations. This ensures `DynamicSaveInput` and `DynamicPatchInput` resolve those fields into their nested Prisma create/update payload shapes. If your repository doesn't manage any relations, you can simply omit this parameter.
+
+**Relation modes:** `oto` (one-to-one), `otm` (one-to-many), `mto` (many-to-one), `mtm` (many-to-many).
+
+**Restrictions:** `set` (replace all) or `add` (add/update without removing).
+
+See the main [README.md](./README.md#relations-in-save) for full details on relation behavior.
+
+---
+
+## Transactions
+
+All methods accept `{ db: tx }` to participate in a transaction:
+
+```typescript
+await userRepository.prisma.$transaction(async (tx) => {
+    const user = await userRepository.save(
+        { name: "Mary", email: "mary@email.com", password: "password" },
+        { db: tx }
+    );
+
+    await postRepository.save(
+        { title: "First Post", authorId: user.id },
+        { db: tx }
+    );
+});
+```
+
+Access the Prisma client via `repository.prisma`.
+
+---
+
+## Working with includes
+
+`DynamicRepository` does not support `includeModels` (named presets), but you can use raw Prisma `include` via `DynamicMethodOptions`:
+
+```typescript
+// Include address only
+const user = await userRepository.get(id, {
+    include: { address: true },
+});
+
+// Nested include
+const userFull = await userRepository.get(id, {
+    include: {
+        address: true,
+        posts: { include: { tags: true } },
+    },
+});
+
+// Works on any method that accepts options
+const all = await userRepository.getAll({
+    include: { posts: true },
+});
+```
+
+---
+
+## DynamicMethodOptions
+
+Every base method and every decorated dynamic method accepts an optional second argument of type `DynamicMethodOptions`. This object has four optional fields:
+
+```typescript
+type DynamicMethodOptions<TName extends PrismaModelName> = {
+    db?: ClientOrTransaction;          // Prisma client or transaction
+    see?: "active" | "removed" | "all"; // Soft-delete visibility
+    include?: IncludeModel<TName>;      // Raw Prisma include
+    select?: SelectModel<TName>;        // Raw Prisma select
+};
+```
+
+> `include` and `select` are mutually exclusive. Unlike the functional `setupVSRepo` API, `DynamicRepository`'s simpler options type doesn't enforce this at compile time — passing both raises a `VSRepoRuntimeError` at runtime.
+
+### `db` — Using a transaction
+
+Pass `{ db: tx }` to route a single method call inside an existing transaction:
+
+```typescript
+await userRepository.prisma.$transaction(async (tx) => {
+    const user = await userRepository.save(
+        { name: "Mary", email: "mary@email.com", password: "password" },
+        { db: tx },
+    );
+
+    await postRepository.save(
+        { title: "First Post", authorId: user.id },
+        { db: tx },
+    );
+});
+```
+
+You can also use the transaction for reads:
+
+```typescript
+await userRepository.prisma.$transaction(async (tx) => {
+    const user = await userRepository.get(id, { db: tx });
+    const total = await userRepository.total({ db: tx });
+});
+```
+
+### `see` — Soft-delete visibility
+
+If `softRemovekName` is configured, the `see` field controls which records are visible:
+
+| Value                | Behavior                        |
+| -------------------- | ------------------------------- |
+| `"active"` (default) | Only non-deleted records        |
+| `"removed"`          | Only soft-deleted records       |
+| `"all"`              | Both active and deleted records |
+
+```typescript
+// Fetch only soft-deleted users
+const deleted = await userRepository.getAll({ see: "removed" });
+
+// Fetch all users including soft-deleted
+const all = await userRepository.getAll({ see: "all" });
+
+// Restore a soft-deleted user by fetching it first
+const [removed] = await userRepository.getAll({ see: "removed", include: { address: true } });
+```
+
+### `include` — Raw Prisma include
+
+Use `include` to eagerly load relations in any method call. This is the equivalent of `includeModels` in the functional approach, but with raw Prisma include syntax:
+
+```typescript
+// Simple include
+const user = await userRepository.get(id, {
+    include: { address: true },
+});
+
+// Nested include
+const userFull = await userRepository.get(id, {
+    include: {
+        address: true,
+        posts: { include: { author: true } },
+    },
+});
+
+// Works on dynamic methods too
+const admin = await userRepository.findAdminByEmail(email, {
+    include: { address: true, posts: true },
+});
+```
+
+### `select` — Raw Prisma select
+
+Use `select` to project a specific set of fields in any method call. This is the equivalent of `selectModels` in the functional approach, but with raw Prisma select syntax:
+
+```typescript
+// Simple select
+const user = await userRepository.get(id, {
+    select: { id: true, email: true },
+});
+
+// Works on dynamic methods too
+const admin = await userRepository.findAdminByEmail(email, {
+    select: { id: true, email: true },
+});
+```
+
+> Because `DynamicRepository` has no `selectModels`/`selectedModel`-driven type narrowing, the return type stays `TEntity` regardless of the `select` passed — the runtime result will only contain the selected fields, but TypeScript won't narrow it for you. Cast or destructure as needed.
+
+### Combining options
+
+`db` and `see` can be freely combined with either `include` or `select` (but not both `include` and `select` together):
+
+```typescript
+// Inside a transaction, fetch a user with relations, including soft-deleted
+await userRepository.prisma.$transaction(async (tx) => {
+    const user = await userRepository.get(id, {
+        db: tx,
+        see: "all",
+        include: { address: true, posts: true },
+    });
+});
+```
+
+---
+
+## NestJS integration
+
+`DynamicRepository` works naturally with NestJS dependency injection.
+
+### Repository provider
+
+```typescript
+// src/modules/user/user.repository.ts
+import { Injectable } from "@nestjs/common";
+import { PrismaService } from "../../database/prisma.service";
+import { DynamicRepository, DynamicMethod, DynamicMethodOptions } from "../../../generated/vsrepo";
+
+type User = /* Prisma UserGetPayload with relations */;
+
+@Injectable()
+class UserRepository extends DynamicRepository<User, "User", string, { profile: true }> {
+    constructor(prisma: PrismaService) {
+        super(prisma, {
+            tableName: "user",
+            pkName: "id",
+            relations: {
+                profile: { mode: "oto", pk: "id", restriction: "add" },
+            },
+            build: {
+                baseMethods: {
+                    save: { ignoreRequiredWhere: true },
+                },
+            },
+        });
+    }
+
+    @DynamicMethod()
+    declare findByEmail: (email: string, options?: DynamicMethodOptions<"User">) => Promise<User | null>;
+}
+
+```
+
+### Registering the module
+
+```typescript
+// src/modules/user/user.module.ts
+import { Module } from "@nestjs/common";
+import { UserRepository } from "./user.repository";
+import { UserService } from "./user.service";
+import { UserController } from "./user.controller";
+
+@Module({
+    providers: [UserRepository, UserService],
+    controllers: [UserController],
+    exports: [UserService],
+})
+export class UserModule {}
+```
+
+### Using in a service
+
+```typescript
+// src/modules/user/user.service.ts
+import { Injectable, Inject } from "@nestjs/common";
+import { UserRepository } from "./user.repository";
+
+@Injectable()
+export class UserService {
+    constructor(
+        private readonly userRepository: UserRepository,
+    ) {}
+
+    async getUserById(id: string) {
+        return this.userRepository.get(id);
+    }
+
+    async getUserAuthByEmailWithProfile(email: string) {
+        return this.userRepository.findByEmail(email, { include: { profile: true } });
+    }
+
+    async createUser(data: { email: string; password: string; name: string }) {
+        return this.userRepository.save({
+            email: data.email,
+            password: data.password,
+            name: data.name,
+        });
+    }
+}
+```
+
+---
+
+## API Reference
+
+### `DynamicRepository<TEntity, UName, VPKType, WRelations>`
+
+```typescript
+abstract class DynamicRepository<
+    TEntity extends object,
+    UName extends PrismaModelName,
+    VPKType,
+    WRelations extends Partial<Record<keyof TEntity, true>> | undefined = undefined,
+>
+```
+
+> `WRelations` is optional (defaults to `undefined`) and only needs to be provided when you're configuring the repository's relations.
+
+**Constructor:**
+
+```typescript
+constructor(prisma: DbClient, config: DynamicRepositoryConstructorConfig<TEntity, UName>)
+```
+
+### DynamicRepositoryConstructorConfig
+
+| Property             | Type                           | Description                    |
+| -------------------- | ------------------------------ | ------------------------------ |
+| `tableName`          | `Uncapitalize<UName>`          | Table name in Prisma           |
+| `pkName`             | `keyof TEntity`                | Primary key field              |
+| `softRemovekName?`   | `keyof TEntity`                | DateTime field for soft-delete |
+| `requiredWhere?`     | `WhereModel<UName>`            | Global filters                 |
+| `defaultOrdering?`   | `OrderingModel<UName>`         | Default ordering               |
+| `relations?`         | `RepositoryRelations<TEntity>` | Relation configuration         |
+| `build?`             | `DynamicRepositoryBuildConfig` | Build-time options             |
+
+### DynamicRepositoryBuildConfig
+
+| Property       | Type                                                | Description                           |
+| -------------- | --------------------------------------------------- | ------------------------------------- |
+| `showWorking?` | `boolean`                                           | Show internal logs (default: `false`) |
+| `baseMethods?` | `Record<string, { ignoreRequiredWhere?: boolean }>` | Per-method config                     |
+
+### @DynamicMethod\<M>(config?)
+
+```typescript
+function DynamicMethod<M extends PrismaModelName>(
+    config?: DynamicMethodConfig<M>,
+): PropertyDecorator;
+```
+
+### DynamicMethodOptions\<TName>
+
+| Property   | Type                             | Description                    |
+| ---------- | -------------------------------- | ------------------------------ |
+| `db?`      | `ClientOrTransaction`            | Database client or transaction |
+| `see?`     | `"active" \| "removed" \| "all"` | Soft-delete visibility         |
+| `include?` | `IncludeModel<TName>`            | Raw Prisma include             |
+| `select?`  | `SelectModel<TName>`             | Raw Prisma select              |
+
+### @QueryMethod(value, options?)
+
+```typescript
+function QueryMethod(value: string, options?: QueryMethodOptions): PropertyDecorator;
+```
+
+### QueryMethodArg\<T>
+
+| Property | Type                  | Description                                                                |
+| -------- | --------------------- | -------------------------------------------------------------------------- |
+| `args`   | `T` (tuple)           | Positional parameters injected into the SQL placeholders (`$1`, `$2`, ...) |
+| `db?`    | `ClientOrTransaction` | Transaction client to run this query in                                    |
+
+### QueryMethodOptions
+
+| Property     | Type      | Default | Description                                                                                                           |
+| ----------   | --------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| `modifying?` | `boolean` | `false` | `true` executes via `$executeRawUnsafe` (field must return `Promise<number>`); `false` executes via `$queryRawUnsafe` |
+
+---
+
+## Differences from setupVSRepo
+
+| Aspect                  | `setupVSRepo`                          | `DynamicRepository`                                   |
+| ----------------------- | -------------------------------------- | ----------------------------------------------------- |
+| **Style**               | Functional / curried                   | OOP / class-based                                     |
+| **Methods defined via** | `methods` config object                | `@DynamicMethod()` decorators                         |
+| **selectModels**        | Supported                              | Not supported                                         |
+| **includeModels**       | Supported                              | Not supported                                         |
+| **Default select**      | `defaultSelectModel` config            | Not available                                         |
+| **Build step**          | Explicit `.build(prisma)`              | Automatic in constructor                              |
+| **Base method toggles** | `active`, `defaultSelect` per method   | Always active, no defaultSelect                       |
+| **Prisma instance**     | Passed at `.build()` time              | Passed to `super()` in constructor                    |
+| **Extensibility**       | `.extend()` method                     | Class inheritance                                     |
+| **Raw includes**        | Via `options.include`                  | Via `DynamicMethodOptions.include`                    |
+| **Raw selects**         | Via `options.select` (type-narrowed)   | Via `DynamicMethodOptions.select` (not type-narrowed) |

--- a/generated/vsrepo/docs/README-DynamicRepo.pt-BR.md
+++ b/generated/vsrepo/docs/README-DynamicRepo.pt-BR.md
@@ -1,0 +1,625 @@
+# DynamicRepository (Abordagem baseada em classes)
+
+🇧🇷 Você está lendo a versão em português. [🇺🇸 Read in English](./README-DynamicRepo.md)
+
+O VSRepository oferece duas formas de criar repositórios: a abordagem funcional `setupVSRepo` e a abordagem OOP baseada em classes `DynamicRepository`. Este documento cobre a abordagem baseada em classes usando `DynamicRepository` e o decorator `@DynamicMethod`.
+
+> Para a abordagem funcional, veja o [README.pt-BR.md](./README.pt-BR.md) principal.
+
+## Sumário
+
+- [Quando usar o DynamicRepository](#quando-usar-o-dynamicrepository)
+- [Requisitos](#requisitos)
+- [Criando uma classe](#criando-uma-classe)
+- [O decorator @DynamicMethod](#o-decorator-dynamicmethod)
+- [Opções de configuração do decorator](#opções-de-configuração-do-decorator)
+- [O decorator @QueryMethod](#o-decorator-querymethod)
+- [Métodos base](#métodos-base)
+- [Trabalhando com relações](#trabalhando-com-relações)
+- [Transações](#transações)
+- [Trabalhando com includes](#trabalhando-com-includes)
+- [DynamicMethodOptions](#dynamicmethodoptions)
+- [Integração com NestJS](#integração-com-nestjs)
+- [Referência da API](#referência-da-api)
+- [Diferenças em relação ao setupVSRepo](#diferenças-em-relação-ao-setupvsrepo)
+
+---
+
+## Quando usar o DynamicRepository
+
+Use `DynamicRepository` quando preferir um **estilo OOP com decorators** em vez da abordagem funcional `setupVSRepo`. Características principais:
+
+- Métodos são definidos como campos `declare` com decorators `@DynamicMethod()`
+- O repositório é uma classe que você pode estender e injetar via injeção de dependência
+- `selectModels` e `includeModels` **não são suportados** (use `select`/`include` brutos via `DynamicMethodOptions`)
+- Os métodos base estão sempre ativos (sem toggle `active` por método)
+- O repositório é construído automaticamente no construtor (sem chamada explícita a `.build()`)
+
+---
+
+## Requisitos
+
+`DynamicRepository` depende dos decorators legados do TypeScript, então o `tsconfig.json` do seu projeto precisa ter:
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}
+```
+
+`reflect-metadata` já é uma dependência do `vsrepo` e é importado internamente — você não precisa importá-lo manualmente.
+
+Sem `experimentalDecorators: true`, o `@DynamicMethod()` não vai compilar (ou vai falhar silenciosamente ao registrar o método em tempo de execução, dependendo da sua ferramenta de build).
+
+---
+
+## Criando uma classe
+
+Estenda `DynamicRepository` com quatro parâmetros genéricos:
+
+```typescript
+import {
+    DynamicRepository,
+    DynamicMethod,
+    DynamicMethodOptions,
+    PaginationModel,
+} from "../../generated/vsrepo";
+import type { Prisma } from "../../generated/prisma/client";
+import { PrismaClient } from "../../generated/prisma/client";
+
+type User = Prisma.UserGetPayload<{
+    include: { address: true; posts: true };
+}>;
+
+class UserRepository extends DynamicRepository<
+    User,        // Tipo da entidade (com relações incluídas)
+    "User",      // Nome do modelo no Prisma
+    string,      // Tipo da chave primária
+    { address: true; posts: true }  // Quais campos são relações (flags)
+> {
+    constructor(prisma: PrismaClient) {
+        super(prisma, {
+            tableName: "user",
+            pkName: "id",
+            relations: {
+                address: { mode: "oto", pk: "id", restriction: "set" },
+                posts: { mode: "otm", pk: "id", restriction: "add" },
+            },
+            requiredWhere: { active: true },
+            build: {
+                showWorking: false,
+                baseMethods: {
+                    save: { ignoreRequiredWhere: true },
+                },
+            },
+        });
+    }
+}
+```
+
+**Parâmetros genéricos:**
+
+| Parâmetro                 | Descrição                                                                                                                                                                              |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TEntity`                 | O tipo completo da entidade, incluindo as relações que você quer disponíveis                                                                                                           |
+| `UName`                   | O nome do modelo no Prisma como string literal (capitalizado, ex.: `"User"`)                                                                                                           |
+| `VPKType`                 | O tipo da chave primária (`string`, `number`, etc.)                                                                                                                                    |
+| `WRelations` *(opcional)* | Um objeto de flags indicando quais campos são relações (ex.: `{ address: true }`). Só é necessário se você for configurar as relações do repository — caso contrário, pode ser omitido |
+
+---
+
+## O decorator @DynamicMethod
+
+Declare métodos dinâmicos como campos de classe usando `declare` e decore-os com `@DynamicMethod()`:
+
+```typescript
+class UserRepository extends DynamicRepository<User, "User", string> {
+    // Método dinâmico simples - o nome determina o comportamento
+    @DynamicMethod()
+    declare findByEmail: (email: string) => Promise<User | null>;
+
+    // Com configuração do decorator
+    @DynamicMethod<"User">({ proxyTo: "findMany", pushWhere: { active: false } })
+    declare findDisabled: () => Promise<User[]>;
+
+    // Proxy para outro método
+    @DynamicMethod<"User">({ proxyTo: "findOneByEmail", whereType: "overwrite" })
+    declare findInternalByEmail: (email: string) => Promise<User | null>;
+}
+```
+
+O **nome** do método determina o comportamento (mesmas regras da abordagem funcional). O objeto de configuração do decorator ajusta esse comportamento.
+
+> **Importante:** Sempre use `declare` (não uma propriedade comum) para campos decorados. O decorator fornece metadados em tempo de execução; a palavra-chave `declare` informa ao TypeScript que a propriedade existe sem emitir código de inicialização.
+
+---
+
+## Opções de configuração do decorator
+
+O decorator `@DynamicMethod<M>()` aceita um objeto de configuração opcional:
+
+```typescript
+@DynamicMethod<"User">({
+    proxyTo: "findByEmail",                   // Delega para outro padrão de método
+    whereType: "overwrite",                   // "extending" (padrão) ou "overwrite"
+    pushWhere: { active: false },             // Cláusula where extra
+    injectOrdering: [{ name: "asc" }],        // Ordenação fixa
+    injectPagination: { skip: 0, take: 10 },  // Paginação fixa
+})
+```
+
+| Opção              | Tipo                         | Descrição                                                                                                                      |
+| ------------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `proxyTo`          | `string`                     | Delega para outro padrão de método válido (ex.: `"findOneByEmail"`)                                                            |
+| `whereType`        | `"extending" \| "overwrite"` | `extending` combina com `requiredWhere`; `overwrite` o ignora                                                                  |
+| `pushWhere`        | `WhereModel<M>`              | Cláusula `where` extra adicionada além do `requiredWhere`                                                                      |
+| `injectOrdering`   | `OrderingModel<M>`           | Ordenação fixa injetada na query                                                                                               |
+| `injectPagination` | `PaginationModel<M>`         | Paginação fixa injetada na query                                                                                               |
+| `fbMode`           | `"one" \| "list"`            | **Deprecated.** Relevante apenas para métodos com prefixo `findBy`. Use `findOneBy` em vez disso se quiser um resultado único. |
+
+---
+
+## O decorator @QueryMethod
+
+`@QueryMethod` declara um **método de SQL bruto** em um campo de classe com `declare`, contornando totalmente o parser de nomes usado por `@DynamicMethod`. É útil para consultas complexas (joins pesados, CTEs, funções específicas do banco) que não são práticas de expressar com os prefixos/sufixos padrão.
+
+Por baixo dos panos, a SQL é executada via Prisma usando `$queryRawUnsafe` (leitura) ou `$executeRawUnsafe` (escrita), e os valores passados em `args` são injetados como **parâmetros posicionais** (`$1`, `$2`, ...) — a mesma técnica de *prepared statements* usada pelo próprio Prisma. Os valores nunca são concatenados na string SQL, o que é o que efetivamente previne SQL Injection.
+
+```typescript
+class UserRepository extends DynamicRepository<User, "User", string> {
+    // Query method de leitura (não-modifying) — o tipo de retorno vem da declaração do campo
+    @QueryMethod('SELECT * FROM "user" WHERE email = $1')
+    declare findByEmailRaw: (arg: QueryMethodArg<[email: string]>) => Promise<User[]>;
+
+    // Query method de escrita — deve sempre resolver para 'number'
+    @QueryMethod('UPDATE "user" SET active = true WHERE id = $1', { modifying: true })
+    declare activateUser: (arg: QueryMethodArg<[id: string]>) => Promise<number>;
+}
+
+const userRepository = new UserRepository(prisma, { tableName: "user", pkName: "id" });
+
+const usuarios = await userRepository.findByEmailRaw({ args: ["joao@email.com"] });
+const afetados = await userRepository.activateUser({ args: ["1"] });
+```
+
+> [!WARNING]
+> `$1`, `$2`, ... devem sempre representar **valores**, nunca nomes de colunas/tabelas ou trechos de SQL dinâmicos. Nomes de identificadores não podem ser passados como parâmetro posicional — se um método precisar variar isso, monte a SQL a partir de um conjunto fixo e conhecido de opções no seu próprio código, nunca a partir de entrada não confiável.
+
+Como `@QueryMethod` pula o parsing de nome, não há inferência automática de tipos para o campo: os tipos de parâmetro e retorno do método vêm inteiramente de como você declara o campo com `declare`. Use `QueryMethodArg<T>` para tipar o único argumento `{ args, db? }` recebido pelo método.
+
+| Opção                  | Tipo      | Padrão  | Descrição                                                                                                                                               |
+| ---------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value` (1º argumento) | `string`  | —       | **Obrigatório.** SQL bruto a ser executado. Use `$1`, `$2`, ... para os placeholders de `args`.                                                         |
+| `options.modifying`    | `boolean` | `false` | Quando `true`, executa via `$executeRawUnsafe`; o campo deve ser declarado retornando `Promise<number>`. Quando `false`, executa via `$queryRawUnsafe`. |
+
+> [!NOTE]
+> `@QueryMethod` ignora todos os outros conceitos de método dinâmico — `requiredWhere`, `pushWhere`, `whereType`, `selectModels`/`includeModels`, `injectOrdering`, `injectPagination`. Nada disso se aplica aqui.
+
+---
+
+## Métodos base
+
+Todas as instâncias de `DynamicRepository` incluem automaticamente estes métodos:
+
+| Método                | Descrição                                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `get(pk)`             | Busca um registro pela chave primária                                                                         |
+| `getOrThrow(pk)`      | Busca pela PK, lança erro se não encontrado                                                                   |
+| `getList(pks)`        | Busca múltiplos registros pelas PKs                                                                           |
+| `save(obj)`           | Cria ou faz upsert de um registro                                                                             |
+| `saveList(objs)`      | Salva em lote em uma transação automática                                                                     |
+| `patch(pk, obj)`      | Atualização parcial pela PK                                                                                   |
+| `patchList(tuples)`   | Atualização parcial em lote via tuplas `[pk, obj]`                                                            |
+| `merge(pk, obj)`      | Busca e faz deep-merge em memória (não persiste)                                                              |
+| `remove(pk)`          | Apaga um registro pela PK                                                                                     |
+| `removeList(pks)`     | Apaga em lote pelas PKs                                                                                       |
+| `getAll()`            | Busca todos os registros (respeita `requiredWhere`). Aceita `pagination` e `order` em `options` — veja abaixo |
+| `total()`             | Conta todos os registros                                                                                      |
+| `has(pk)`             | Verifica se um registro existe                                                                                |
+| `softRemove(pk)`      | Soft-delete (requer configuração de `softRemovekName`)                                                        |
+| `softRemoveList(pks)` | Soft-delete em lote                                                                                           |
+| `restore(pk)`         | Restaura registro com soft-delete                                                                             |
+| `restoreList(pks)`    | Restauração em lote                                                                                           |
+
+Todos os métodos aceitam um argumento opcional `options` baseado em `DynamicMethodOptions` (`db`, `see`, `include`, `select`), mas alguns métodos restringem esse tipo:
+
+- **`getAll`** aceita adicionalmente `pagination?: PaginationOptions` e `order?: OrderingModel<UName>` (usa `defaultOrdering` quando omitido).
+- **`saveList` / `patchList`** omitem `include` e `select`, e `db` só aceita uma `DbTransaction` (o retorno de `prisma.$transaction`) — não o client Prisma comum.
+- **`removeList`, `total`, `has`** omitem `include` e `select`.
+- **`softRemove`, `restore`** omitem `see` (a visibilidade de soft-delete não se aplica ao registro sendo alterado).
+- **`softRemoveList`, `restoreList`** omitem `see`, `include` e `select`.
+
+```typescript
+// getAll com paginação e ordenação
+const page = await userRepository.getAll({
+    pagination: { skip: 0, take: 20 },
+    order: { createdAt: "desc" },
+});
+```
+
+---
+
+## Trabalhando com relações
+
+Configure as relações no construtor para que `save` e `patch` as gerenciem automaticamente:
+
+```typescript
+class UserRepository extends DynamicRepository<
+    User, "User", string,
+    { address: true; posts: true }
+> {
+    constructor(prisma: PrismaClient) {
+        super(prisma, {
+            tableName: "user",
+            pkName: "id",
+            relations: {
+                address: { mode: "oto", pk: "id", restriction: "set" },
+                posts: { mode: "otm", pk: "id", restriction: "add" },
+            },
+        });
+    }
+}
+```
+
+O quarto parâmetro genérico (`WRelations`) é **opcional** — só é necessário quando você for configurar as relações do repository. Quando fornecido, ele deve sinalizar quais campos são relações. Isso garante que `DynamicSaveInput` e `DynamicPatchInput` resolvam esses campos para o formato de payload aninhado de create/update do Prisma. Se o seu repository não gerenciar nenhuma relação, você pode simplesmente omitir esse parâmetro.
+
+**Modos de relação:** `oto` (um-para-um), `otm` (um-para-muitos), `mto` (muitos-para-um), `mtm` (muitos-para-muitos).
+
+**Restrições:** `set` (substitui tudo) ou `add` (adiciona/atualiza sem remover).
+
+Veja o [README.pt-BR.md](./README.pt-BR.md#relações-no-save) principal para todos os detalhes sobre o comportamento das relações.
+
+---
+
+## Transações
+
+Todos os métodos aceitam `{ db: tx }` para participar de uma transação:
+
+```typescript
+await userRepository.prisma.$transaction(async (tx) => {
+    const user = await userRepository.save(
+        { name: "Mary", email: "mary@email.com", password: "password" },
+        { db: tx }
+    );
+
+    await postRepository.save(
+        { title: "First Post", authorId: user.id },
+        { db: tx }
+    );
+});
+```
+
+Acesse o client do Prisma via `repository.prisma`.
+
+---
+
+## Trabalhando com includes
+
+`DynamicRepository` não suporta `includeModels` (presets nomeados), mas você pode usar um `include` bruto do Prisma via `DynamicMethodOptions`:
+
+```typescript
+// Incluir apenas address
+const user = await userRepository.get(id, {
+    include: { address: true },
+});
+
+// Include aninhado
+const userFull = await userRepository.get(id, {
+    include: {
+        address: true,
+        posts: { include: { tags: true } },
+    },
+});
+
+// Funciona em qualquer método que aceite options
+const all = await userRepository.getAll({
+    include: { posts: true },
+});
+```
+
+---
+
+## DynamicMethodOptions
+
+Todo método base e todo método dinâmico decorado aceita um segundo argumento opcional do tipo `DynamicMethodOptions`. Esse objeto tem quatro campos opcionais:
+
+```typescript
+type DynamicMethodOptions<TName extends PrismaModelName> = {
+    db?: ClientOrTransaction;          // Client ou transação do Prisma
+    see?: "active" | "removed" | "all"; // Visibilidade do soft-delete
+    include?: IncludeModel<TName>;      // Include bruto do Prisma
+    select?: SelectModel<TName>;        // Select bruto do Prisma
+};
+```
+
+> `include` e `select` são mutuamente exclusivos. Diferente da API funcional `setupVSRepo`, o tipo de options mais simples do `DynamicRepository` não garante isso em tempo de compilação — passar os dois gera um `VSRepoRuntimeError` em tempo de execução.
+
+### `db` — Usando uma transação
+
+Passe `{ db: tx }` para direcionar uma única chamada de método para dentro de uma transação existente:
+
+```typescript
+await userRepository.prisma.$transaction(async (tx) => {
+    const user = await userRepository.save(
+        { name: "Mary", email: "mary@email.com", password: "password" },
+        { db: tx },
+    );
+
+    await postRepository.save(
+        { title: "First Post", authorId: user.id },
+        { db: tx },
+    );
+});
+```
+
+Você também pode usar a transação para leituras:
+
+```typescript
+await userRepository.prisma.$transaction(async (tx) => {
+    const user = await userRepository.get(id, { db: tx });
+    const total = await userRepository.total({ db: tx });
+});
+```
+
+### `see` — Visibilidade do soft-delete
+
+Se `softRemovekName` estiver configurado, o campo `see` controla quais registros ficam visíveis:
+
+| Valor               | Comportamento                    |
+| ------------------- | -------------------------------- |
+| `"active"` (padrão) | Apenas registros não removidos   |
+| `"removed"`         | Apenas registros com soft-delete |
+| `"all"`             | Registros ativos e removidos     |
+
+```typescript
+// Busca apenas usuários com soft-delete
+const deleted = await userRepository.getAll({ see: "removed" });
+
+// Busca todos os usuários, incluindo os com soft-delete
+const all = await userRepository.getAll({ see: "all" });
+
+// Restaura um usuário com soft-delete buscando-o primeiro
+const [removed] = await userRepository.getAll({ see: "removed", include: { address: true } });
+```
+
+### `include` — Include bruto do Prisma
+
+Use `include` para carregar relações de forma antecipada (eager loading) em qualquer chamada de método. É o equivalente ao `includeModels` da abordagem funcional, mas com a sintaxe bruta de include do Prisma:
+
+```typescript
+// Include simples
+const user = await userRepository.get(id, {
+    include: { address: true },
+});
+
+// Include aninhado
+const userFull = await userRepository.get(id, {
+    include: {
+        address: true,
+        posts: { include: { author: true } },
+    },
+});
+
+// Também funciona em métodos dinâmicos
+const admin = await userRepository.findAdminByEmail(email, {
+    include: { address: true, posts: true },
+});
+```
+
+### `select` — Select bruto do Prisma
+
+Use `select` para projetar um conjunto específico de campos em qualquer chamada de método. É o equivalente ao `selectModels` da abordagem funcional, mas com a sintaxe bruta de select do Prisma:
+
+```typescript
+// Select simples
+const user = await userRepository.get(id, {
+    select: { id: true, email: true },
+});
+
+// Também funciona em métodos dinâmicos
+const admin = await userRepository.findAdminByEmail(email, {
+    select: { id: true, email: true },
+});
+```
+
+> Como o `DynamicRepository` não tem estreitamento de tipo orientado por `selectModels`/`selectedModel`, o tipo de retorno permanece `TEntity` independentemente do `select` passado — o resultado em tempo de execução conterá apenas os campos selecionados, mas o TypeScript não vai estreitar isso para você. Faça cast ou desestruture conforme necessário.
+
+### Combinando opções
+
+`db` e `see` podem ser combinados livremente com `include` ou `select` (mas não com os dois juntos):
+
+```typescript
+// Dentro de uma transação, busca um usuário com relações, incluindo os com soft-delete
+await userRepository.prisma.$transaction(async (tx) => {
+    const user = await userRepository.get(id, {
+        db: tx,
+        see: "all",
+        include: { address: true, posts: true },
+    });
+});
+```
+
+---
+
+## Integração com NestJS
+
+`DynamicRepository` funciona naturalmente com a injeção de dependência do NestJS.
+
+### Provider do repositório
+
+```typescript
+// src/modules/user/user.repository.ts
+import { Injectable } from "@nestjs/common";
+import { PrismaService } from "../../database/prisma.service";
+import { DynamicRepository, DynamicMethod, DynamicMethodOptions } from "../../../generated/vsrepo";
+
+type User = /* Prisma UserGetPayload com relações */;
+
+@Injectable()
+class UserRepository extends DynamicRepository<User, "User", string, { profile: true }> {
+    constructor(prisma: PrismaService) {
+        super(prisma, {
+            tableName: "user",
+            pkName: "id",
+            relations: {
+                profile: { mode: "oto", pk: "id", restriction: "add" },
+            },
+            build: {
+                baseMethods: {
+                    save: { ignoreRequiredWhere: true },
+                },
+            },
+        });
+    }
+
+    @DynamicMethod()
+    declare findByEmail: (email: string, options?: DynamicMethodOptions<"User">) => Promise<User | null>;
+}
+
+```
+
+### Registrando o módulo
+
+```typescript
+// src/modules/user/user.module.ts
+import { Module } from "@nestjs/common";
+import { UserRepository } from "./user.repository";
+import { UserService } from "./user.service";
+import { UserController } from "./user.controller";
+
+@Module({
+    providers: [UserRepository, UserService],
+    controllers: [UserController],
+    exports: [UserService],
+})
+export class UserModule {}
+```
+
+### Usando em um service
+
+```typescript
+// src/modules/user/user.service.ts
+import { Injectable, Inject } from "@nestjs/common";
+import { UserRepository } from "./user.repository";
+
+@Injectable()
+export class UserService {
+    constructor(
+        private readonly userRepository: UserRepository,
+    ) {}
+
+    async getUserById(id: string) {
+        return this.userRepository.get(id);
+    }
+
+    async getUserAuthByEmailWithProfile(email: string) {
+        return this.userRepository.findByEmail(email, { include: { profile: true } });
+    }
+
+    async createUser(data: { email: string; password: string; name: string }) {
+        return this.userRepository.save({
+            email: data.email,
+            password: data.password,
+            name: data.name,
+        });
+    }
+}
+```
+
+---
+
+## Referência da API
+
+### `DynamicRepository<TEntity, UName, VPKType, WRelations>`
+
+```typescript
+abstract class DynamicRepository<
+    TEntity extends object,
+    UName extends PrismaModelName,
+    VPKType,
+    WRelations extends Partial<Record<keyof TEntity, true>> | undefined = undefined,
+>
+```
+
+> `WRelations` é opcional (o padrão é `undefined`) e só precisa ser informado quando você for configurar as relações do repository.
+
+**Construtor:**
+
+```typescript
+constructor(prisma: DbClient, config: DynamicRepositoryConstructorConfig<TEntity, UName>)
+```
+
+### DynamicRepositoryConstructorConfig
+
+| Propriedade          | Tipo                           | Descrição                       |
+| -------------------- | ------------------------------ | ------------------------------- |
+| `tableName`          | `Uncapitalize<UName>`          | Nome da tabela no Prisma        |
+| `pkName`             | `keyof TEntity`                | Campo da chave primária         |
+| `softRemovekName?`   | `keyof TEntity`                | Campo DateTime para soft-delete |
+| `requiredWhere?`     | `WhereModel<UName>`            | Filtros globais                 |
+| `defaultOrdering?`   | `OrderingModel<UName>`         | Ordenação padrão                |
+| `relations?`         | `RepositoryRelations<TEntity>` | Configuração de relações        |
+| `build?`             | `DynamicRepositoryBuildConfig` | Opções de build                 |
+
+### DynamicRepositoryBuildConfig
+
+| Propriedade    | Tipo                                                | Descrição                             |
+| -------------- | --------------------------------------------------- | ------------------------------------- |
+| `showWorking?` | `boolean`                                           | Exibe logs internos (padrão: `false`) |
+| `baseMethods?` | `Record<string, { ignoreRequiredWhere?: boolean }>` | Configuração por método               |
+
+### @DynamicMethod\<M>(config?)
+
+```typescript
+function DynamicMethod<M extends PrismaModelName>(
+    config?: DynamicMethodConfig<M>,
+): PropertyDecorator;
+```
+
+### DynamicMethodOptions\<TName>
+
+| Propriedade | Tipo                             | Descrição                             |
+| ----------- | -------------------------------- | ------------------------------------- |
+| `db?`       | `ClientOrTransaction`            | Client ou transação do banco de dados |
+| `see?`      | `"active" \| "removed" \| "all"` | Visibilidade do soft-delete           |
+| `include?`  | `IncludeModel<TName>`            | Include bruto do Prisma               |
+| `select?`   | `SelectModel<TName>`             | Select bruto do Prisma                |
+
+### @QueryMethod(value, options?)
+
+```typescript
+function QueryMethod(value: string, options?: QueryMethodOptions): PropertyDecorator;
+```
+
+### QueryMethodArg\<T>
+
+| Propriedade | Tipo                  | Descrição                                                                  |
+| ----------- | --------------------- | -------------------------------------------------------------------------- |
+| `args`      | `T` (tupla)           | Parâmetros posicionais injetados nos placeholders da SQL (`$1`, `$2`, ...) |
+| `db?`       | `ClientOrTransaction` | Client de transação para executar essa query                               |
+
+### QueryMethodOptions
+
+| Propriedade  | Tipo      | Padrão  | Descrição                                                                                                               |
+|------------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `modifying?` | `boolean` | `false` | `true` executa via `$executeRawUnsafe` (o campo deve retornar `Promise<number>`); `false` executa via `$queryRawUnsafe` |
+
+---
+
+## Diferenças em relação ao setupVSRepo
+
+| Aspecto                    | `setupVSRepo`                                    | `DynamicRepository`                                           |
+| -------------------------- | ------------------------------------------------ | ------------------------------------------------------------- |
+| **Estilo**                 | Funcional / curried                              | OOP / baseado em classes                                      |
+| **Métodos definidos via**  | Objeto de configuração `methods`                 | Decorators `@DynamicMethod()`                                 |
+| **selectModels**           | Suportado                                        | Não suportado                                                 |
+| **includeModels**          | Suportado                                        | Não suportado                                                 |
+| **Select padrão**          | Configuração `defaultSelectModel`                | Não disponível                                                |
+| **Etapa de build**         | `.build(prisma)` explícito                       | Automático no construtor                                      |
+| **Toggles de método base** | `active`, `defaultSelect` por método             | Sempre ativo, sem defaultSelect                               |
+| **Instância do Prisma**    | Passada no `.build()`                            | Passada para `super()` no construtor                          |
+| **Extensibilidade**        | Método `.extend()`                               | Herança de classe                                             |
+| **Includes brutos**        | Via `options.include`                            | Via `DynamicMethodOptions.include`                            |
+| **Selects brutos**         | Via `options.select` (com estreitamento de tipo) | Via `DynamicMethodOptions.select` (sem estreitamento de tipo) |

--- a/generated/vsrepo/docs/README.md
+++ b/generated/vsrepo/docs/README.md
@@ -1,0 +1,1600 @@
+# VSRepository
+
+![npm](https://img.shields.io/npm/v/vsrepo?style=flat-square)
+![NPM License](https://img.shields.io/npm/l/vsrepo?style=flat-square)
+![NPM Downloads](https://img.shields.io/npm/dt/vsrepo?style=flat-square)
+
+🇺🇸 You're reading the English version. [🇧🇷 Ler em português](./README.pt-BR.md)
+
+Repository pattern library for projects using **Prisma**, with full **TypeScript** support and automatic **type inference**.
+
+VSRepository lets you create strongly-typed repositories with:
+
+- Automatic **base methods**: `get`, `getOrThrow`, `getList`, `save`, `saveList`, `remove`, `removeList`, `patch`, `patchList`, `merge`, `getAll`, `total`, `has`
+- **Native soft-delete**: `softRemove`, `softRemoveList`, `restore`, `restoreList`
+- **Dynamic methods** inferred from their name: `findOneByEmail`, `findManyPaginated`, `updateById`, `deleteManyByNameStartsWith`
+- Reusable **select models** for different data projections
+- **Type safety** across 100% of operations
+- Native Prisma **transactions** (automatic in `saveList` and `patchList`)
+- **Extensibility** with custom methods
+
+> 💡 Want to see all of this in practice? The repository's [`examples/`](https://github.com/jaobrabo123/VSRepository/tree/main/examples) folder has commented, runnable examples for every feature — see the [Practical examples](#practical-examples) section below.
+
+---
+
+## Table of contents
+
+- [Installation](#installation)
+- [Generating the types](#generating-the-types)
+- [Basic usage](#basic-usage)
+- [Class-based approach (DynamicRepository)](#class-based-approach-dynamicrepository)
+- [NestJS integration](#nestjs-integration)
+- [Base methods](#base-methods)
+  - [Soft-delete](#soft-delete)
+  - [Batch operations](#batch-operations)
+  - [Merge](#merge)
+  - [Configuring the base methods](#configuring-the-base-methods)
+- [Select Models](#select-models)
+  - [Raw select (options.select)](#raw-select-optionsselect)
+- [Include Models](#include-models)
+  - [Raw include (options.include)](#raw-include-optionsinclude)
+- [Required Where](#required-where)
+- [Default Ordering](#default-ordering)
+- [`see` option](#see-option)
+- [Dynamic methods](#dynamic-methods)
+  - [Available prefixes](#available-prefixes)
+  - [Field filters](#field-filters)
+  - [Logical operators](#logical-operators)
+  - [Relation filters](#relation-filters)
+  - [Pagination and ordering suffixes](#pagination-and-ordering-suffixes)
+  - [Distinct](#distinct)
+  - [Method configuration](#method-configuration)
+  - [Aggregate and GroupBy](#aggregate-and-groupby)
+  - [Query Methods](#query-methods)
+- [Relations in save](#relations-in-save)
+- [Transactions](#transactions)
+- [Extending a repository](#extending-a-repository)
+- [Error handling](#error-handling)
+- [Utility types](#utility-types)
+- [API Reference](#api-reference)
+- [Practical examples](#practical-examples)
+- [Contributing](#contributing)
+- [Requirements](#requirements)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Installation
+
+```bash
+npm i vsrepo @prisma/client
+```
+
+Generate the Prisma Client:
+
+```bash
+npx prisma generate
+```
+
+---
+
+## Generating the types
+
+VSRepository needs to know the real path of your Prisma Client to generate the typings correctly.
+
+```bash
+npx vsrepo generate
+```
+
+Equivalent to:
+
+```bash
+npx vsrepo generate \
+  --output generated/vsrepo \
+  --prisma generated/prisma
+```
+
+**Available flags:**
+
+| Flag       | Alias | Default              |
+| ---------- | ----- | -------------------- |
+| `--output` | `-o`  | `generated/vsrepo`   |
+| `--prisma` | `-p`  | `generated/prisma`   |
+
+**Generated files:**
+
+```text
+generated/vsrepo/
+├── DynamicRepository.ts
+├── DynamicRepository.types.d.ts
+├── VSRepoError.ts
+├── VSRepoError.types.d.ts
+├── VSRepository.ts
+├── VSRepository.types.d.ts
+└── index.ts
+```
+
+After generating, always import from the generated folder:
+
+```ts
+// CORRECT ✅
+import { setupVSRepo } from "../../generated/vsrepo";
+
+// WRONG ❌
+import { setupVSRepo } from "vsrepo";
+```
+
+---
+
+## Basic usage
+
+### Configuring the Prisma Client
+
+```ts
+// src/configs/db.ts
+import { PrismaClient } from '../../generated/prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import 'dotenv/config';
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+const prisma = new PrismaClient({ adapter });
+
+export default prisma;
+```
+
+### Creating a repository
+
+```ts
+// src/repositories/userRepository.ts
+import prisma from "../configs/db";
+import { setupVSRepo } from "../../generated/vsrepo";
+import type { User } from "../../generated/prisma/client";
+
+const userRepository = setupVSRepo<User, "User">()(({
+  tableName: "user",
+  pkName: "id",
+  selectModels: {
+    public: { id: true, name: true, email: true },
+  },
+  defaultSelectModel: "public",
+}).build(prisma);
+
+export default userRepository;
+```
+
+### Using the repository
+
+```ts
+import userRepository from "./repositories/userRepository";
+
+const user = await userRepository.save({
+  name: "John",
+  email: "john@email.com",
+  password: "password",
+});
+
+const found = await userRepository.get(user.id);
+const all = await userRepository.getAll();
+
+user.name = "John Smith";
+
+await userRepository.save(user);
+await userRepository.remove(user.id);
+```
+
+---
+
+## Class-based approach (DynamicRepository)
+
+If you prefer an OOP style with decorators instead of the functional `setupVSRepo` approach, VSRepository also provides `DynamicRepository` — a class you can extend with `@DynamicMethod()` decorators to define your dynamic methods.
+
+See **[README-DynamicRepo.md](./README-DynamicRepo.md)** (or the [pt-BR version](./README-DynamicRepo.pt-BR.md)) for full documentation on the class-based approach, including NestJS integration examples, decorator config, and a comparison with `setupVSRepo`.
+
+---
+
+## NestJS integration
+
+VSRepository can be easily integrated into NestJS projects through providers. Below is a complete example using NestJS's dependency injection pattern.
+
+### Configuring the repository as a provider
+
+```ts
+// src/modules/user/user.repository.ts
+import { Provider } from "@nestjs/common";
+import { PrismaService } from "../../database/prisma.service";
+import { UserGetPayload } from "../../../generated/prisma/models";
+import { setupVSRepo } from "../../../generated/vsrepo";
+
+const userVSRepo = setupVSRepo<
+    UserGetPayload<{ include: { profile: true } }>,
+    "User"
+>()(({
+    tableName: "user",
+    pkName: "id",
+    selectModels: {
+        public: {
+            id: true,
+            email: true,
+            createdAt: true,
+            updatedAt: true,
+        },
+        auth: {
+            id: true,
+            email: true,
+            password: true,
+        },
+    },
+    defaultSelectModel: "public",
+    requiredWhere: {
+        deletedAt: null,
+    },
+    relations: {
+        profile: {
+            mode: "oto",
+            pk: "id",
+            restriction: "add",
+        },
+    },
+    methods: {
+        findAuthByEmail: {
+            map: true,
+            proxyTo: "findUniqueByEmail",
+            selectModel: "auth",
+        },
+        findByEmailEndsWith: {
+            map: true,
+        }
+    },
+});
+
+const setupUserRepository = (prisma: PrismaService) => {
+    return userVSRepo.build(prisma);
+};
+
+export type UserRepository = ReturnType<typeof setupUserRepository>;
+/* 
+The type can also be inferred using VSRepository's `RepositoryOf`, passing the `userVSRepo` type:
+
+export type UserRepository = RepositoryOf<typeof userVSRepo>;
+
+NOTE: If you use `.extend` to extend the repository or configure the base methods,
+using `ReturnType` is recommended since it's simpler to infer the type
+*/
+
+export const USER_REPOSITORY = Symbol("USER_REPOSITORY");
+
+export const UserRepositoryProvider: Provider = {
+    provide: USER_REPOSITORY,
+    inject: [PrismaService],
+    useFactory: setupUserRepository,
+};
+```
+
+### Registering the provider in the module
+
+```ts
+// src/modules/user/user.module.ts
+import { Module } from "@nestjs/common";
+import { UserRepositoryProvider } from "./user.repository";
+import { UserService } from "./user.service";
+import { UserController } from "./user.controller";
+
+@Module({
+    imports: [DatabaseModule],
+    providers: [UserRepositoryProvider, UserService],
+    controllers: [UserController],
+    exports: [UserService],
+})
+export class UserModule {}
+```
+
+### Using the repository in a service
+
+```ts
+// src/modules/user/user.service.ts
+import { Injectable, Inject } from "@nestjs/common";
+import { USER_REPOSITORY, type UserRepository } from "./user.repository";
+
+@Injectable()
+export class UserService {
+    constructor(
+        @Inject(USER_REPOSITORY)
+        private readonly userRepository: UserRepository,
+    ) {}
+
+    async getUserById(id: string) {
+        return this.userRepository.get(id);
+    }
+
+    async getUserAuthByEmail(email: string) {
+        return this.userRepository.findAuthByEmail(email);
+    }
+
+    async createUser(data: { email: string; password: string; name: string }) {
+        return this.userRepository.save({
+            email: data.email,
+            password: data.password,
+            name: data.name,
+        });
+    }
+}
+```
+
+**Benefits of this approach:**
+
+- ✅ Type-safe repositories with dependency injection
+- ✅ Easy to test (mock the `USER_REPOSITORY`)
+- ✅ Isolation of persistence logic
+- ✅ Repository reuse across multiple services
+- ✅ Transaction support via `PrismaService`
+
+---
+
+## Base methods
+
+When calling `.build(prisma)`, the base methods below are automatically made available:
+
+| Method                   | Description                                                                                                  |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------|
+| `get(pk)`                | Fetches a record by its primary key                                                                          |
+| `getOrThrow(pk)`         | Fetches a record by its primary key; throws `VSRepoRuntimeError` (code `"20727"`) if not found               |
+| `getList(pks)`           | Fetches multiple records from a list of primary keys                                                         |
+| `save(obj)`              | Creates or updates — if the object has a `pk` it performs an `upsert`, otherwise a `create`                  |
+| `saveList(objs)`         | Saves an array of objects in a single automatic transaction                                                  |
+| `patch(pk, obj)`         | Partially updates a record by its primary key                                                                |
+| `patchList(tuples)`      | Partially updates multiple records via an array of `[pk, obj]` tuples in an automatic transaction            |
+| `merge(pk, obj)`         | Fetches a record and deep merges it in memory — **does not persist**, returns the merged object              |
+| `remove(pk)`             | Removes a record by its primary key                                                                          |
+| `removeList(pks)`        | Removes several records by a list of primary keys — returns `{ count }`                                      |
+| `getAll()`               | Returns all records (accepts `pagination` and `order` in `options`)                                          |
+| `total()`                | Returns the total number of records                                                                          |
+| `has(pk)`                | Checks whether a record exists by its primary key — returns `boolean`                                        |
+
+All of them accept `options` as the last argument.
+
+### Soft-delete
+
+When `softRemovekName` is configured on the repository, the following additional methods become available:
+
+| Method                     | Description                                                                        |
+| -------------------------- | ---------------------------------------------------------------------------------- |
+| `softRemove(pk)`           | Marks a record as removed by filling `softRemovekName` with the current date       |
+| `softRemoveList(pks)`      | Marks multiple records as removed in batch — returns `{ count }`                   |
+| `restore(pk)`              | Restores a soft-deleted record, clearing the `softRemovekName` field               |
+| `restoreList(pks)`         | Restores multiple soft-deleted records in batch — returns `{ count }`              |
+
+```ts
+const userRepository = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+  softRemovekName: "deletedAt", // must be a DateTime field in the Prisma schema
+}).build(prisma);
+
+await userRepository.softRemove(1);
+await userRepository.restore(1);
+```
+
+> The field provided in `softRemovekName` **must** be of type `DateTime` in the Prisma schema. VSRepository validates this at `build` time and throws `VSRepoBuildError` if the type is incorrect.
+
+### Batch operations
+
+`saveList` and `patchList` automatically run all operations inside a single Prisma transaction. If any operation fails, all previous ones are rolled back.
+
+```ts
+// saveList — creates or updates multiple objects in an automatic transaction
+const users = await userRepository.saveList([
+  { name: "Mary", email: "mary@email.com" },
+  { id: 2, name: "John Updated", email: "john@email.com" },
+]);
+
+// patchList — partially updates multiple records via [pk, obj] tuples
+const updated = await userRepository.patchList([
+  [1, { active: false }],
+  [2, { name: "New Name" }],
+]);
+```
+
+When you're already inside an existing transaction, pass it in `options.db`. In this case, `db` must be a `DbTransaction` (not the main client):
+
+```ts
+await prisma.$transaction(async (tx) => {
+  await userRepository.saveList([{ name: "Mary" }, { name: "Gus" }], { db: tx });
+  await userRepository.patchList([[1, { active: false }], [2, { active: true }]], { db: tx });
+});
+```
+
+### Merge
+
+The `merge` method fetches a record by its PK and deeply merges (`deepmerge`) the provided object with the existing data **in memory**. It **does not persist** the changes — it returns the merged result so you can decide what to do with it.
+
+```ts
+const existing = await userRepository.get(1);
+// existing: { id: 1, name: "Mary", profile: { bio: "Hi", age: 25 } }
+
+const merged = await userRepository.merge(1, {
+  profile: { bio: "Updated bio" },
+});
+// merged: { id: 1, name: "Mary", profile: { bio: "Updated bio", age: 25 } }
+
+// To persist, pass it to save or patch:
+await userRepository.save(merged);
+```
+
+Returns `null` if the record is not found.
+
+**Merging to-many relations (`otm`/`mtm`) is done by PK, not by simple concatenation.** For to-one relations (`oto`/`mto`), `merge` performs a regular deep merge of the object. For to-many relations, each item in the sent array is matched against the existing item that has the same PK (defined in `relations[key].pk`): if the PK matches, the two objects are merged together; if it doesn't match (a new item with no counterpart), it's simply added to the list. Existing items that don't appear in the sent array are kept.
+
+```ts
+const existing = await userRepository.get(1);
+// existing: {
+//   id: 1,
+//   posts: [
+//     { id: 10, title: "Post A", published: false },
+//     { id: 11, title: "Post B", published: true },
+//   ],
+// }
+
+const merged = await userRepository.merge(1, {
+  posts: [
+    { id: 10, published: true },  // same PK (id: 10) → merges with the existing item
+    { title: "Post C" },          // no PK → added as a new item
+  ],
+});
+// merged: {
+//   id: 1,
+//   posts: [
+//     { id: 10, title: "Post A", published: true },  // merged
+//     { id: 11, title: "Post B", published: true },  // kept, wasn't in the sent array
+//     { title: "Post C" },                            // added
+//   ],
+// }
+```
+
+> Note that `merge` never removes items from a to-many relation — it only merges the ones that match by PK and adds the ones that don't. To remove items from a relation, use `save`/`patch` with `restriction: "set"` in the relation configuration.
+
+### Configuring the base methods
+
+The second argument of `.build(prisma, config)` lets you adjust the repository's global behavior and customize each base method individually through `baseMethods`.
+
+```ts
+userVSRepo.build(prisma, {
+  // Shows VSRepository's internal logs on the console (built queries, detected prefix,
+  // applied filters, etc). Great for debugging dynamic methods. Default = false.
+  showWorking: true,
+
+  baseMethods: {
+    get: {
+      // Enables/disables the method on the final repository. If `false`, the method
+      // doesn't even appear in the repository's type (it's not just a runtime error). Default = true.
+      active: true,
+
+      // Select model applied by default when the method is called without `options.selectModel`.
+      // Overrides the `defaultSelectModel` from setupVSRepo for this method only.
+      defaultSelect: "public",
+    },
+    remove: {
+      active: true,
+      defaultSelect: "minimal",
+
+      // When `true`, ignores the `requiredWhere` configured in setupVSRepo for
+      // this specific method — useful when a method needs to "punch through" a
+      // global filter (e.g. multi-tenancy) in a specific case. Default = false.
+      ignoreRequiredWhere: false,
+    },
+    save: {
+      // Here only `ignoreRequiredWhere` is set — `active` and `defaultSelect`
+      // keep their defaults (true and the global `defaultSelectModel`).
+      ignoreRequiredWhere: true,
+    },
+    patch: {
+      // Only the select is overridden; the method stays active normally.
+      defaultSelect: "minimal",
+    },
+    has: {
+      active: false, // Disables 'has' (default = true) — the method disappears from the repository
+    },
+    softRemove: {
+      // Soft-delete methods follow the same options (`active`, `defaultSelect`,
+      // `ignoreRequiredWhere`). They're only available if `softRemovekName` is configured.
+      active: true,
+      defaultSelect: "minimal",
+    },
+  },
+});
+```
+
+> Batch/aggregate methods like `removeList`, `softRemoveList`, `restoreList`, `total`, and `has` **do not** accept `defaultSelect` (they don't return a selectable record — they return `{ count }` or `boolean`). In these cases `BaseMethodConfig` is restricted to `active` and `ignoreRequiredWhere`.
+
+---
+
+## Select Models
+
+`selectModels` defines named, reusable data projections.
+
+```ts
+selectModels: {
+  public:   { id: true, name: true, email: true },
+  internal: { id: true, name: true, email: true, password: true },
+  minimal:  { id: true },
+},
+defaultSelectModel: "public",
+```
+
+`defaultSelectModel` defines which select is used automatically when none is specified in the call. It's recommended to always define it together with `selectModels`.
+
+**Using a specific select in the call:**
+
+```ts
+const user = await userRepository.get(id, { selectModel: "minimal" });
+```
+
+**Returning Prisma's default payload (without select):**
+
+```ts
+const fullUser = await userRepository.get(id, { selectModel: false });
+```
+
+### Raw `select` (`options.select`)
+
+Besides `selectModel` (named, pre-configured in `selectModels`), you can pass a raw Prisma `select` directly in the call, without registering it beforehand on the repository.
+
+```ts
+const user = await userRepository.get(id, {
+  select: { id: true, name: true },
+});
+```
+
+`options.select` accepts any valid Prisma `select` for the repository's model — it's fully typed and offers the same autocomplete/validation as calling `prisma.user.findMany({ select: ... })` directly, and the method's return type is narrowed to exactly the fields selected.
+
+**Rules and behavior:**
+
+- **Mutually exclusive with `selectModel`, `includeModel` and `include`.** Only one of the four can be provided per call; the types enforce this — passing more than one is a compile-time error.
+- **Ad hoc, not reusable.** Unlike `selectModel`, it doesn't need to be declared in `selectModels`. Use it for one-off projections that don't justify a named select model.
+- **No `defaultSelectModel` is applied.** When `select` is provided, the default select (`defaultSelectModel`) is ignored and only the raw `select` is sent to Prisma.
+
+```ts
+// CORRECT ✅ — raw select only
+await userRepository.get(id, { select: { id: true, name: true } });
+
+// WRONG ❌ — combining select with selectModel/includeModel/include is not allowed
+await userRepository.get(id, { selectModel: "public", select: { id: true } });
+await userRepository.get(id, { include: { posts: true }, select: { id: true } });
+```
+
+> **When to use `selectModel` vs. `select`:** prefer `selectModel` for projections reused across multiple calls (defined once in `selectModels`); use `select` for specific, occasional projections that don't need a name.
+
+---
+
+## Include Models
+
+`includeModels` works similarly to `selectModels`, but instead of receiving a `select`, it receives a valid Prisma `include`.
+
+```ts
+const userRepository = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+  selectModels: {
+    public: { id: true, name: true, email: true },
+  },
+  defaultSelectModel: "public",
+  includeModels: {
+    withPosts: { posts: true },
+    withPostsAndProfile: { posts: true, profile: true },
+  },
+}).build(prisma);
+```
+
+**Using an `includeModel` in the call:**
+
+```ts
+const user = await userRepository.get(id, { includeModel: "withPosts" });
+```
+
+In this case, the default `select` (`selectModels`/`defaultSelectModel`) is ignored and only the `include` is sent to Prisma.
+
+### Differences from `selectModels`
+
+- **Can only be passed in the method call**, via `options.includeModel`. There's no `defaultIncludeModel` or `defaultInclude` — there's no way to configure a default `includeModel` on the repository, unlike what happens with `defaultSelectModel`.
+- **`includeModel` and `selectModel` cannot be passed together** in the same call. If an `includeModel` is provided, any `selectModel` (including the default one) is ignored.
+
+```ts
+// CORRECT ✅ — includeModel only
+await userRepository.get(id, { includeModel: "withPosts" });
+
+// CORRECT ✅ — selectModel only
+await userRepository.get(id, { selectModel: "public" });
+
+// WRONG ❌ — combining both is not allowed
+await userRepository.get(id, { selectModel: "public", includeModel: "withPosts" });
+```
+
+### Raw `include` (`options.include`)
+
+Besides `includeModel` (named, pre-configured in `includeModels`), you can pass a raw Prisma `include` directly in the call, without registering it beforehand on the repository.
+
+```ts
+const user = await userRepository.get(id, {
+  include: { posts: true, profile: true },
+});
+```
+
+`options.include` accepts any valid `include` for the repository's Prisma model — it's fully typed and offers the same autocomplete/validation as calling `prisma.user.findMany({ include: ... })` directly.
+
+**Rules and behavior:**
+
+- **Mutually exclusive with `selectModel` and `includeModel`.** Only one of the three can be provided per call; the types enforce this — passing more than one is a compile-time error.
+- **Ad hoc, not reusable.** Unlike `includeModel`, it doesn't need to be declared in `includeModels`. Use it for one-off includes that don't justify a named model.
+- **No `selectModel` default is applied.** As with `includeModel`, when `include` is provided the select (including `defaultSelectModel`) is ignored and only the `include` is sent to Prisma.
+
+```ts
+// CORRECT ✅ — raw include only
+await userRepository.get(id, { include: { posts: true } });
+
+// WRONG ❌ — combining include with selectModel/includeModel is not allowed
+await userRepository.get(id, { selectModel: "public", include: { posts: true } });
+await userRepository.get(id, { includeModel: "withPosts", include: { posts: true } });
+```
+
+> **When to use `includeModel` vs. `include`:** prefer `includeModel` for includes reused across multiple calls (defined once in `includeModels`); use `include` for specific, occasional includes that don't need a name.
+
+---
+
+## Required Where
+
+`requiredWhere` defines filters that are automatically applied to every query on the repository.
+
+```ts
+requiredWhere: { active: true },
+```
+
+Now every query will automatically include `active: true`:
+
+```ts
+// Internally: WHERE active = true
+const users = await userRepository.findMany();
+
+// Internally: WHERE email = 'john@email.com' AND active = true
+const user = await userRepository.findByEmail("john@email.com");
+```
+
+Useful for manual soft-deletes, multi-tenancy, and global filters of any kind.
+
+---
+
+## Default Ordering
+
+`defaultOrdering` defines a default ordering that's automatically applied to every query that accepts `orderBy`, without needing to repeat the `order` argument on every call.
+
+```ts
+const userRepository = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+  defaultOrdering: { createdAt: "desc" },
+}).build(prisma);
+```
+
+With this, every listing query will already come ordered by `createdAt` descending:
+
+```ts
+// Internally: ORDER BY createdAt DESC
+const users = await userRepository.getAll();
+
+// Also applies to getAll with pagination
+const paginated = await userRepository.getAll({ pagination: { take: 10 } });
+```
+
+**`defaultOrdering` is ignored when:**
+
+- The method uses the `Ordered`, `OrderedAndPaginated`, or `PaginatedAndOrdered` suffix — in these cases the `order` argument passed in the call takes priority.
+- The dynamic method has `injectOrdering` configured — the method's fixed ordering takes precedence.
+
+```ts
+methods: {
+  findManyPaginatedAndOrdered: { map: true },         // order comes from the argument → defaultOrdering ignored
+  findManyByActive:            { map: true },         // no Ordered → defaultOrdering applied
+  findManyByStatus: {
+    map: true,
+    injectOrdering: { name: "asc" },                  // injectOrdering → defaultOrdering ignored
+  },
+}
+```
+
+> `defaultOrdering` accepts the same type as Prisma's native `orderBy` for the model — including arrays of chained orderings.
+
+---
+
+## `see` option
+
+When `softRemovekName` is configured, every method accepts the `see` option to control the visibility of soft-deleted records:
+
+| Value       | Behavior                                                      |
+| ----------- | --------------------------------------------------------------|
+| `"active"`  | Returns only records that are **not** removed (default)       |
+| `"removed"` | Returns only removed records                                  |
+| `"all"`     | Returns all records, regardless of status                     |
+
+```ts
+// Returns only active users (default)
+const active = await userRepository.getAll();
+
+// Returns only removed users
+const removed = await userRepository.getAll({ see: "removed" });
+
+// Returns all
+const all = await userRepository.getAll({ see: "all" });
+```
+
+> The `see` option works independently of `requiredWhere` — it's applied on top of the soft-delete filter, not as a replacement for it.
+
+---
+
+## Dynamic methods
+
+Dynamic methods are defined in the `methods` property and have their behavior inferred from their name.
+
+```ts
+methods: {
+  findOneByEmail:     { map: true },
+  findManyPaginated:  { map: true },
+  updateById:         { map: true },
+  deleteManyByIdIn:   { map: true },
+}
+```
+
+---
+
+### Available prefixes
+
+The method name's prefix determines which Prisma operation will be called and which arguments are expected.
+
+| Prefix                       | Prisma operation           | Return                   | Notes                                                                                                     |
+| ---------------------------- | -------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `findOneBy`                  | `findFirst`                | `T \| null`              | Single return.                                                                                            |
+| `findBy`                     | `findMany` / `findFirst`   | `T[]` or `T \| null`     | Default is list; use `fbMode: "one"` for a single return (**deprecated**, use `findOneBy`)                |
+| `findUniqueBy`               | `findUnique`               | `T \| null`              |                                                                                                           |
+| `findUniqueOrThrowBy`        | `findUniqueOrThrow`        | `T`                      | Throws an error if not found                                                                              |
+| `findFirstBy`                | `findFirst`                | `T \| null`              | Accepts fields as filter                                                                                  |
+| `findFirstOrThrowBy`         | `findFirstOrThrow`         | `T`                      | Accepts fields as filter; throws an error if not found                                                    |
+| `findFirst`                  | `findFirst`                | `T \| null`              | No field filters; applies only `requiredWhere` and `pushWhere`                                            |
+| `findFirstOrThrow`           | `findFirstOrThrow`         | `T`                      | No field filters; applies only `requiredWhere` and `pushWhere`; throws an error if not found              |
+| `findManyBy`                 | `findMany`                 | `T[]`                    | Accepts fields as filter                                                                                  |
+| `findMany`                   | `findMany`                 | `T[]`                    | No field filters; applies only `requiredWhere` and `pushWhere`                                            |
+| `findOneWhere`               | `findFirst`                | `T \| null`              | Receives an explicit `where` object as argument                                                           |
+| `findListWhere`              | `findMany`                 | `T[]`                    | Receives an explicit `where` object as argument                                                           |
+| `existsBy`                   | `findFirst`                | `boolean`                | Returns `true` if found, `false` otherwise                                                                |
+| `existsWhere`                | `findFirst`                | `boolean`                | Receives an explicit `where` object and returns whether it exists                                         |
+| `countBy`                    | `count`                    | `number`                 | Accepts fields as filter                                                                                  |
+| `countWhere`                 | `count`                    | `number`                 | Receives an explicit `where` object as argument                                                           |
+| `count`                      | `count`                    | `number`                 | No field filters; applies only `requiredWhere` and `pushWhere`                                            |
+| `create`                     | `create`                   | `T`                      | Receives `data` as argument                                                                               |
+| `createMany`                 | `createMany`               | `{ count: number }`      | Receives `data` as argument; supports `SkipDuplicates`                                                    |
+| `createManyAndReturn`        | `createManyAndReturn`      | `T[]`                    | Receives `data` as argument; supports `SkipDuplicates`                                                    |
+| `updateBy`                   | `update`                   | `T`                      | Receives `data` as argument                                                                               |
+| `updateManyBy`               | `updateMany`               | `{ count: number }`      | Receives `data` as argument                                                                               |
+| `updateManyWhere`            | `updateMany`               | `{ count: number }`      | Receives a `where` object and a `data` object as arguments                                                |
+| `updateManyAndReturnBy`      | `updateManyAndReturn`      | `T[]`                    | Receives `data` as argument                                                                               |
+| `updateManyAndReturnWhere`   | `updateManyAndReturn`      | `T[]`                    | Receives a `where` object and a `data` object as arguments                                                |
+| `upsertBy`                   | `upsert`                   | `T`                      | Receives `update` and `create` as arguments                                                               |
+| `deleteBy`                   | `delete`                   | `T`                      |                                                                                                           |
+| `deleteManyBy`               | `deleteMany`               | `{ count: number }`      |                                                                                                           |
+| `deleteManyWhere`            | `deleteMany`               | `{ count: number }`      | Receives an explicit `where` object as argument                                                           |
+| `aggregate`                  | `aggregate`                | `Dynamic`                | Name must be exact; receives native Prisma args; ignores `selectModels`, `pushWhere`, and `requiredWhere` |
+| `groupBy`                    | `groupBy`                  | `Dynamic[]`              | Name must be exact; receives native Prisma args; ignores `selectModels`, `pushWhere`, and `requiredWhere` |
+
+---
+
+### Field filters
+
+Filters are suffixes applied to the field name inside the method. The field itself comes capitalized right after the prefix (or after `By`).
+
+| Suffix               | Prisma operator        | Argument required          |
+| -------------------- | ---------------------- | ---------------------------|
+| *(no suffix)*        | equality (`=`)         | yes                        |
+| `Not`                | `not`                  | yes                        |
+| `In`                 | `in`                   | yes (array)                |
+| `NotIn`              | `notIn`                | yes (array)                |
+| `Contains`           | `contains`             | yes                        |
+| `NotContains`        | `not.contains`         | yes                        |
+| `StartsWith`         | `startsWith`           | yes                        |
+| `NotStartsWith`      | `not.startsWith`       | yes                        |
+| `EndsWith`           | `endsWith`             | yes                        |
+| `NotEndsWith`        | `not.endsWith`         | yes                        |
+| `GreaterThan`        | `gt`                   | yes                        |
+| `GreaterThanEqual`   | `gte`                  | yes                        |
+| `LessThan`           | `lt`                   | yes                        |
+| `LessThanEqual`      | `lte`                  | yes                        |
+| `Between`            | `gte` + `lte`          | yes (tuple `[min, max]`)   |
+| `NotBetween`         | `not.gte` + `not.lte`  | yes (tuple `[min, max]`)   |
+| `IsNull`             | `null`                 | no                         |
+| `IsNotNull`          | `not: null`            | no                         |
+| `IsTrue`             | `true`                 | no                         |
+| `IsFalse`            | `false`                | no                         |
+| `Insensitive`        | `mode: 'insensitive'`  | combinator                 |
+
+`Insensitive` is a combinator and can be used together with another text filter:
+
+```ts
+findByNameContainsInsensitive    // { name: { contains: value, mode: 'insensitive' } }
+findByEmailStartsWithInsensitive // { email: { startsWith: value, mode: 'insensitive' } }
+findByNameInsensitive            // { name: { equals: value, mode: 'insensitive' } }
+```
+
+`Between` and `NotBetween` receive a **tuple `[minValue, maxValue]`**:
+
+```ts
+methods: {
+  findManyByAgeBetween:      { map: true },
+  findManyBySalaryNotBetween: { map: true },
+  findManyByCreatedAtBetween: { map: true },
+}
+
+await userRepository.findManyByAgeBetween([18, 65]);
+await userRepository.findManyBySalaryNotBetween([1000, 5000]);
+await userRepository.findManyByCreatedAtBetween([new Date("2024-01-01"), new Date("2024-12-31")]);
+```
+
+The `Optional` suffix can be added to any field to make the argument optional:
+
+```ts
+findByNameOptionalAndEmail // name is optional, email is required
+```
+
+---
+
+### Logical operators
+
+| Operator  | Usage in the name              | Example                            |
+| --------- | ------------------------------ | ---------------------------------- |
+| `And`     | between two fields             | `findOneByIdAndEmail`              |
+| `Or`      | between two fields             | `findByNameOrEmail`                |
+| `AND`     | separates a final `AND` block  | `findByEmailOrNameANDActiveStatus` |
+
+`AND` (in caps) has a specific rule:
+
+- Only **one** `AND` can exist per method.
+- All fields after `AND` are injected inside `AND: []`.
+- After an `AND`, there can't be an `Or`.
+
+Example:
+
+```ts
+methods: {
+  findOneByIdAndEmail:   { map: true },
+  findByNameOrEmail:  { map: true },
+  findFirstByIdOrEmailAndName: { map: true },
+  findByEmailOrNameANDActiveStatusAndAgeGreaterThan: { map: true }
+}
+
+await userRepository.findOneByIdAndEmail(1, "john@email.com");
+await userRepository.findByNameOrEmail("John", "john@email.com");
+await userRepository.findFirstByIdOrEmailAndName(1, "john@email.com", "John");
+await userRepository.findByEmailOrNameANDActiveStatusAndAgeGreaterThan("john@email.com", "John", true, 17)
+```
+
+Generates (`findOneByIdAndEmail`):
+
+```ts
+{
+  id: 1,
+  email: "john@email.com"
+}
+```
+
+Generates (`findByNameOrEmail`):
+
+```ts
+{
+  OR: [
+    { name: "John" },
+    { email: "john@email.com" }
+  ]
+}
+```
+
+Generates (`findFirstByIdOrEmailAndName`):
+
+```ts
+{
+  OR: [
+    { id: 1 },
+    {
+      email: "john@email.com",
+      name: "John"
+    }
+  ]
+}
+```
+
+Generates (`findByEmailOrNameANDActiveStatusAndAgeGreaterThan`):
+
+```ts
+{
+  OR: [
+    { email: "john@email.com" },
+    { name: "John" }
+  ],
+  AND: [
+    { activeStatus: true },
+    { age: { gt: 17 } }
+  ]
+}
+```
+
+---
+
+### Relation filters
+
+Allow filtering by fields of related models.
+
+> [!IMPORTANT]
+>
+> - **Relation typing**: For TypeScript to recognize the types of relation fields in dynamic methods, the generic entity type passed to `setupVSRepo` must include the structured relations (e.g. using Prisma's `UserGetPayload<{ include: { profile: true, posts: true } }>`).
+> - **Suffix compatibility**:
+>   - The `Some`, `Every`, and `None` suffixes only work for **to-many** relations (`many-to-many` and `one-to-many`).
+>   - The `With` and `Without` suffixes only work for **to-one** relations (`one-to-one` and `many-to-one`).
+
+| Relation suffix       | Prisma operator   | Note                                                  |
+| --------------------- | ----------------- | ----------------------------------------------------- |
+| `Some`                | `some: {}`        | Relation has *some* record                            |
+| `SomeField`           | `some.field`      | Filters within the relation's records                 |
+| `EveryField`          | `every.field`     | Filters within the relation's records                 |
+| `None`                | `none: {}`        | Relation has *no* records                             |
+| `NoneField`           | `none.field`      | Filters within the relation's records                 |
+| `With`                | `is: {}`          | Relation exists (not null)                            |
+| `WithField`           | `is.field`        | Filters a field within the relation                   |
+| `Without`             | `isNot: {}`       | Relation doesn't exist (is null)                      |
+| `WithoutField`        | `isNot.field`     | Filters a field within the relation with negation     |
+
+Considering `user` with a to-one relation `profile` and a to-many relation `posts`:
+
+```ts
+methods: {
+  // to-many (posts)
+  findByPostsSome:                { map: true }, // has at least one post
+  findByPostsSomeTitle:           { map: true }, // has at least one post with that title
+  findByPostsEveryPublishedIsTrue:{ map: true }, // all posts are published
+  findByPostsNone:                { map: true }, // has no posts
+  findByPostsNoneTitle:           { map: true }, // no post has that title
+
+  // to-one (profile)
+  findByProfileWith:             { map: true }, // has a profile (not null)
+  findByProfileWithBio:          { map: true }, // has a profile with that bio
+  findByProfileWithout:          { map: true }, // has no profile (is null)
+  findByProfileWithoutBio:       { map: true }, // has a profile, but with a different bio than the one provided
+}
+
+await userRepository.findByPostsSome();
+await userRepository.findByPostsSomeTitle("My first post");
+await userRepository.findByPostsEveryPublishedIsTrue();
+await userRepository.findByPostsNone();
+await userRepository.findByPostsNoneTitle("Draft");
+
+await userRepository.findByProfileWith();
+await userRepository.findByProfileWithBio("Hello, world!");
+await userRepository.findByProfileWithout();
+await userRepository.findByProfileWithoutBio("Old bio");
+```
+
+Generates (`findByPostsSomeTitle`):
+
+```ts
+{
+  posts: {
+    some: { title: "My first post" }
+  }
+}
+```
+
+Generates (`findByPostsEveryPublishedIsTrue`):
+
+```ts
+{
+  posts: {
+    every: { published: true }
+  }
+}
+```
+
+Generates (`findByProfileWithBio`):
+
+```ts
+{
+  profile: {
+    is: { bio: "Hello, world!" }
+  }
+}
+```
+
+Generates (`findByProfileWithout`):
+
+```ts
+{
+  profile: {
+    isNot: {}
+  }
+}
+```
+
+> `Some`, `None`, `With`, and `Without` (without a field) don't receive an argument — the whole relation is tested for the existence of records (`some`/`none`) or for being `null`/not `null` (`is`/`isNot`). The `SomeField`, `EveryField`, `NoneField`, `WithField`, and `WithoutField` variants receive the filtered field's value as an argument.
+
+---
+
+### Pagination and ordering suffixes
+
+Applied at the **end** of the method name, they automatically inject the pagination and ordering arguments.
+
+| Suffix                   | Additional arguments           |
+| ------------------------ | -------------------------------|
+| `Paginated`              | `(pagination)`                 |
+| `Ordered`                | `(order)`                      |
+| `OrderedAndPaginated`    | `(order, pagination)`          |
+| `PaginatedAndOrdered`    | `(pagination, order)`          |
+
+For `createMany` and `createManyAndReturn`, the `SkipDuplicates` suffix is available:
+
+| Suffix              | Effect                                     |
+| ------------------- | ------------------------------------------ |
+| `SkipDuplicates`    | Skips duplicate records during insertion   |
+
+---
+
+### Distinct
+
+The `Distinct` suffix lets you get only unique records based on one or more fields, equivalent to Prisma's `distinct` option.
+
+To use it, put `Distinct` in the method name (after the field filters, if any) followed by the desired fields separated by `And`. The first character of each field must be uppercase, just like in regular field filters.
+
+```ts
+methods: {
+    // Returns unique users combining "age" and "role" (no field filter)
+    findManyDistinctAgeAndRole: { map: true },
+
+    // Distinct combined with the Paginated suffix
+    findManyDistinctNamePaginated: { map: true },
+
+    // Distinct combined with a field filter (name) — filters by name and then applies distinct on role
+    findManyByNameDistinctRole: { map: true },
+},
+```
+
+```ts
+// No arguments: the distinct fields are already fixed in the method name
+await userRepository.findManyDistinctAgeAndRole();
+
+// The pagination argument still works normally
+await userRepository.findManyDistinctNamePaginated({ take: 10, skip: 0 });
+
+// The "name" field filter is still passed normally as an argument
+await userRepository.findManyByNameDistinctRole("John");
+```
+
+> The fields specified after `Distinct` are resolved from the method name at build time — they **don't** become runtime arguments, unlike regular field filters.
+
+`Distinct` is available on prefixes that read multiple or single records: `findMany`, `findManyBy`, `findFirst`, `findFirstBy`, `findFirstOrThrow`, `findFirstOrThrowBy`, `findBy`, `findOneBy`, `findWhere`, `findOneWhere`, `findListWhere`, `existsBy`, and `existsWhere`.
+
+---
+
+### Method configuration
+
+Each entry in `methods` accepts the following options:
+
+| Option                | Type                                     | Default        | Description                                                                                                                 |
+| --------------------- | ---------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `map`                 | `boolean`                                | —              | **Required.** Defines whether the method will be exposed on the repository.                                                 |
+| `whereType`           | `'extending'` \| `'overwrite'`           | `extending`    | `extending` combines with `requiredWhere`. `overwrite` ignores `requiredWhere`.                                             |
+| `selectModel`         | `keyof SelectModels \| false`            | —              | Overrides `defaultSelectModel` for this method.                                                                             |
+| `fbMode`              | `'one'` \| `'list'`                      | `'list'`       | (**Deprecated. Use `findOneBy`**) Only for `findBy`. `'one'` returns `T \| null`; `'list'` returns `T[]`.                   |
+| `proxyTo`             | `Valid method pattern`                   | —              | Delegates the logic to another valid method pattern.                                                                        |
+| `pushWhere`           | `WhereModel<M>`                          | —              | Extra `where` added to the query in addition to `requiredWhere`.                                                            |
+| `injectOrdering`      | `OrderingModel<M>`                       | —              | Fixed ordering automatically injected into the query.                                                                       |
+| `injectPagination`    | `PaginationModel<M>`                     | —              | Fixed pagination automatically injected into the query.                                                                     |
+| `query`               | `{ value: string; modifying?: boolean }` | —              | Turns the method into a **Query Method** (raw SQL). Ignores every other option above — see [Query Methods](#query-methods). |
+
+---
+
+### Aggregate and GroupBy
+
+```ts
+const userRepository = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+  methods: {
+    aggregate: { map: true },
+    groupBy: { map: true },
+  },
+}).build(prisma);
+```
+
+> [!NOTE]
+> These methods must have exactly these names (`aggregate` and `groupBy`).
+> Unlike the other dynamic methods, they receive native Prisma arguments and **ignore** the `selectModels`, `pushWhere`, and `requiredWhere` configurations.
+
+---
+
+### Query Methods
+
+Query Methods let a method run **raw SQL** directly, completely bypassing the dynamic-method name parser. They're useful for complex queries (heavy joins, CTEs, database-specific functions) that aren't practical to express with the standard prefixes/suffixes.
+
+Internally, VSRepository executes the SQL through Prisma using `$queryRawUnsafe` (for reads) or `$executeRawUnsafe` (for writes), and the values in the `args` array are passed as **positional parameters** (`$1`, `$2`, ...) — the same prepared-statement technique Prisma itself uses. This means the values are never concatenated into the SQL string, which is what actually prevents SQL injection.
+
+> [!WARNING]
+> `$1`, `$2`, ... in your SQL must always represent **values** (data parameters), never column names, table names, or dynamic SQL fragments. Identifier names (columns/tables) can't be passed as a positional parameter — if your method needs to vary those, build the SQL from a fixed, known set of options in your own code, never from untrusted input.
+
+```ts
+const userRepository = setupVSRepo<User, "user">()({
+  tableName: "user",
+  pkName: "id",
+  methods: {
+    // Read query method (non-modifying)
+    findActiveUsersRaw: {
+      map: true,
+      query: {
+        value: 'SELECT * FROM "user" WHERE active = $1',
+      },
+    },
+
+    // Write query method (modifying: true)
+    deactivateUsersOlderThanRaw: {
+      map: true,
+      query: {
+        value: 'UPDATE "user" SET active = false WHERE "createdAt" < $1',
+        modifying: true,
+      },
+    },
+  },
+}).build(prisma);
+```
+
+**Calling a Query Method:**
+
+Every Query Method takes a single argument shaped as `{ args: [...], db? }`:
+
+```ts
+// Non-modifying: returns 'any' by default, but accepts a generic to
+// infer/assert the return type right at the call site
+const activeUsers = await userRepository.findActiveUsersRaw<User[]>({
+  args: [true],
+});
+
+// Modifying: always returns 'number' (count of affected rows)
+const affected = await userRepository.deactivateUsersOlderThanRaw({
+  args: [new Date("2024-01-01")],
+});
+
+// Participating in a transaction, via 'db'
+await userRepository.prisma.$transaction(async (tx) => {
+  await userRepository.deactivateUsersOlderThanRaw({
+    args: [new Date("2024-01-01")],
+    db: tx,
+  });
+});
+```
+
+| Option        | Type      | Default | Description                                                                                                                                                                                                                               |
+| ------------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value`       | `string`  | —       | **Required.** Raw SQL to execute. Use `$1`, `$2`, ... for the placeholders of the values in `args`.                                                                                                                                       |
+| `modifying`   | `boolean` | `false` | When `true`, executes via `$executeRawUnsafe` and the method always resolves to `number`. When `false`, executes via `$queryRawUnsafe` and the method resolves to `TReturn` (`any` by default, inferable via a generic at the call site). |
+
+> [!NOTE]
+> Unlike the other dynamic methods, Query Methods **completely ignore** `selectModels`, `requiredWhere`, `pushWhere`, `whereType`, `injectOrdering`, `injectPagination`, and `proxyTo` — none of that applies, since there's no name parsing or `where`/`select` assembly by VSRepository. Free-form method names (outside the `findBy`, `updateBy`, etc. patterns) also **don't** require `proxyTo`.
+
+The same functionality is available in the class-based approach via the `@QueryMethod` decorator — see [README-DynamicRepo.md](./README-DynamicRepo.md#the-querymethod-decorator).
+
+---
+
+## Relations in save
+
+Configure relations so that `save` and `patch` manage them automatically (`saveList` and `patchList` also manage relations automatically).
+
+```ts
+import type { Prisma } from "../../generated/prisma/client";
+
+type User = Prisma.userGetPayload<{
+  include: { profile: true; posts: true };
+}>;
+
+const userRepository = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+
+  relations: {
+    profile: {
+      pk: "id",
+      mode: "oto",
+      restriction: "set",
+    },
+    posts: {
+      pk: "id",
+      mode: "otm",
+      restriction: "add",
+    },
+  },
+}).build(prisma);
+```
+
+**Relation modes:**
+
+| Mode  | Relation       |
+| ----- | -------------- |
+| `oto` | one-to-one     |
+| `otm` | one-to-many    |
+| `mto` | many-to-one    |
+| `mtm` | many-to-many   |
+
+**Restrictions:**
+
+| Restriction  | Behavior on update                                     |
+| ------------ | ------------------------------------------------------ |
+| `set`        | Fully replaces (removes the ones that weren't sent)    |
+| `add`        | Adds/updates without removing existing ones            |
+
+> [!WARNING]
+> **`set` means different things depending on the relation's `mode` — and this can cause data loss if you're not careful.**
+>
+> In relations where the related record **belongs** to the parent record (`oto` and `otm`), "removing the ones that weren't sent" means **deleting the record from the database** (`delete`/`deleteMany`). In relations where the related record is **independent** (`mto` and `mtm`), "removing" just means **unlinking** (`disconnect`/`set: []`) — the related record continues to exist in the database, it just stops pointing to the parent (or being in the join table).
+>
+> | Mode | `restriction: "set"` when an item is omitted | Does the item continue to exist in the database? |
+> | ----- | ------------------------------------------------ | ----------------------------------------------------- |
+> | `oto` | Passing `null` in the field → **deletes** the related record (`delete: true`) | No |
+> | `otm` | Items outside the sent list → **deleted** (`deleteMany` with `notIn`) | No |
+> | `mto` | Passing `null` in the field (with `nullable: true`) → **unlinks** (`disconnect: true`) | Yes |
+> | `mtm` | Items outside the sent list → **unlinked** from the join table (`set: []`) | Yes |
+>
+> Practical example: if `posts` is `otm` with `restriction: "set"`, a `save`/`patch` that sends the user with only 2 of the 5 existing posts will **delete the other 3 posts from the database**, not just unlink them from the user. If the expected behavior is just to unlink without deleting, use `restriction: "add"` (which never removes anything) and handle removal manually.
+
+**`mto` relation with nullable:**
+
+Use `nullable` (lowercase) to allow unlinking a many-to-one relation:
+
+```ts
+relations: {
+  category: {
+    pk: "id",
+    mode: "mto",
+    restriction: "set",
+    nullable: true, // allows passing null to unlink
+  },
+}
+```
+
+---
+
+## Transactions
+
+All methods accept `options.db` to participate in a transaction:
+
+```ts
+await userRepository.prisma.$transaction(async (tx) => {
+  const user = await userRepository.save(
+    { name: "Mary", email: "mary@email.com", password: "password" },
+    { db: tx }
+  );
+
+  await userLogsRepository.save(
+    { action: "User registration", data: { registeredUser: user.id } },
+    { db: tx }
+  );
+});
+```
+
+For `saveList` and `patchList`, the `db` field must be a `DbTransaction`:
+
+```ts
+await prisma.$transaction(async (tx) => {
+  // CORRECT: tx is a DbTransaction
+  const registeredUsers = await userRepository.saveList([{ name: "Mary" }, { name: "Lucas" }], { db: tx });
+
+  await userLogsRepository.save(
+    { action: "User registration", data: { registeredUsers: registeredUsers.map(u => u.id) } },
+    { db: tx }
+  );
+});
+```
+
+---
+
+## Extending a repository
+
+```ts
+const userRepository = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+  methods: {
+    findOneByEmailEndsWith: { map: true },
+  },
+})
+  .build(prisma)
+  .extend((repo) => ({
+    findActiveByDomain: async (domain: string) => {
+      return repo.findOneByEmailEndsWith(`@${domain}`);
+    },
+
+    activateMultiple: async (ids: string[]) => {
+      return repo.patchList(ids.map(id => [id, { active: true }]));
+    },
+  }));
+```
+
+---
+
+## Error handling
+
+VSRepository throws `VSRepoError` and its subclasses in specific situations (Prisma errors are not overridden):
+
+```ts
+import { VSRepoError, VSRepoRuntimeError } from "../../generated/vsrepo";
+
+try {
+  const user = await userRepository.getOrThrow("id-that-does-not-exist");
+} catch (error) {
+  if (error instanceof VSRepoRuntimeError && error.code === "20727") {
+    console.error("Record not found");
+  } else if (error instanceof VSRepoError) {
+    console.error("Repository error:", error.message);
+  } else {
+    console.error("Error:", error.message)
+  }
+}
+```
+
+**Available subclasses:**
+
+| Class                   | When it's thrown                                                         |
+| ----------------------- | ------------------------------------------------------------------------ |
+| `VSRepoConfigError`     | Invalid configuration in `setupVSRepo`                                   |
+| `VSRepoBuildError`      | Invalid method name, field type, or configuration in `build`             |
+| `VSRepoExtendError`     | Invalid argument in `extend`                                             |
+| `VSRepoDecoratorError`  | Invalid argument passed to `@DynamicMethod` or `@QueryMethod`            |
+| `VSRepoRuntimeError`    | Runtime error during an operation                                        |
+
+`VSRepoRuntimeError` has a `code: VSRepoRuntimeErrorCode` property for programmatic identification, instead of having to parse the (human-readable, and possibly localized) message:
+
+| Code | Meaning |
+| ---- | ------- |
+| `"65706"` | A required argument is missing or has an invalid shape — e.g. a missing `pk`, a `pks`/`objs`/`tuples` that isn't an array, or an `options`/`obj` that isn't a valid object. |
+| `"20727"` | No record was found for the provided primary key (`getOrThrow` when fetching the base record). |
+| `"67542"` | Validation (zod) of a method's `options`, or of a `@QueryMethod` argument, failed. |
+| `"91868"` | A relation passed to `save`/`patch`/`merge` has an invalid shape for the configured `mode`/`restriction` (e.g. `null` on a `mtm`/`otm` relation, or an array on a `oto`/`mto` relation). |
+| `"48670"` | A dynamic method (`config.methods`) was called with fewer positional arguments than its `where` fields require. |
+
+---
+
+## Utility types
+
+### Client types
+
+```ts
+import type { DbClient, DbTransaction, ClientOrTransaction } from "../../generated/vsrepo";
+
+type DbClient            = PrismaClient;
+type DbTransaction       = Prisma.TransactionClient;
+type ClientOrTransaction = DbClient | DbTransaction;
+```
+
+### Soft-delete visibility type
+
+```ts
+import type { SeeMode } from "../../generated/vsrepo";
+
+type SeeMode = "active" | "removed" | "all";
+```
+
+### Types derived from the Prisma model
+
+```ts
+import type {
+  SelectModel,
+  SelectModels,
+  IncludeModel,
+  IncludeModels,
+  WhereModel,
+  OrderingModel,
+  PaginationModel,
+  ModelUpsertInput,
+  PrismaModelInputs,
+} from "../../generated/vsrepo";
+```
+
+### Method options types
+
+```ts
+import type { MethodOptions, MethodOptionsModel } from "../../generated/vsrepo";
+
+// MethodOptions<S, IM> — options passed into the repository's methods
+type Opts = MethodOptions<"public" | "minimal", "withPosts">;
+
+// MethodOptionsModel<TRepo> — derived from a configured VSRepository instance
+const userVSRepo = setupVSRepo<User, "user">()(config);
+type OptsModel = MethodOptionsModel<typeof userVSRepo>;
+```
+
+> The second parameter of `MethodOptions` (`IM`) represents the valid keys of `includeModels`. When provided, `selectModel` and `includeModel` become mutually exclusive in the type — it's not possible to pass both in the same call.
+>
+> `MethodOptions` also accepts two further generic parameters, `RI` and `RS`, for typing raw `include` and raw `select` respectively (both default to `never`, meaning they're not accepted unless explicitly typed): `MethodOptions<"public", "withPosts", "user", IncludeModel<"user">, SelectModel<"user">>`. `MethodOptionsModel`, derived directly from a configured repository, does not expose `RI`/`RS` — use `MethodOptions` directly if you need to type raw `include`/`select` options.
+
+### Configuration types
+
+```ts
+import type {
+  MethodConfig,
+  RepoConfig,
+  BuildConfig,
+  RepositoryRelations,
+  ExtractRelationConfig,
+} from "../../generated/vsrepo";
+```
+
+### Built repository type
+
+```ts
+import type { RepositoryOf } from "../../generated/vsrepo";
+
+const userVSRepo = setupVSRepo<User, "user">()({ ... });
+type UserRepository = RepositoryOf<typeof userVSRepo>;
+```
+
+`RepositoryOf` accepts three parameters:
+
+```ts
+type RepositoryOf<TRepo, C extends BuildConfig | undefined = undefined, E = unknown>
+```
+
+### `save` and `patch` payload types
+
+```ts
+import type { SaveObject, PatchObject } from "../../generated/vsrepo";
+
+const userVSRepo = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+  relations: {
+    profile: { pk: "id", mode: "oto", restriction: "set" },
+  },
+});
+
+type UserSavePayload  = SaveObject<Prisma.UserCreateInput, typeof userVSRepo>;
+type UserPatchPayload = PatchObject<Prisma.UserUpdateInput, typeof userVSRepo>;
+```
+
+---
+
+## API Reference
+
+### `setupVSRepo<T, M>()(config)`
+
+```ts
+setupVSRepo<TPayload, TTableName>()({
+  tableName: Uncapitalize<M>;                     // Table name in Prisma
+  pkName: keyof T;                                // Primary key name
+  softRemovekName?: keyof T & string;             // DateTime field for soft-delete
+  selectModels?: SelectModels<M>;                 // Named data projections (select)
+  defaultSelectModel?: keyof SM;                  // Select applied by default
+  includeModels?: IncludeModels<M>;               // Named data projections (include) — no default, only in the call
+  requiredWhere?: WhereModel<M>;                  // Always-applied filters
+  defaultOrdering?: OrderingModel<M>;             // Default ordering for queries without Ordered/injectOrdering
+  relations?: RepositoryRelations<T>;             // Relation configuration
+  methods?: Record<string, MethodConfig<M, SM>>;  // Dynamic methods
+});
+```
+
+### `.build(prisma, config?)`
+
+```ts
+vsRepo.build(prisma, {
+  showWorking?: boolean;   // Shows internal logs on the console (default = false)
+
+  baseMethods?: {
+    // Methods that can use a defaultSelect
+    get?:             { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    getOrThrow?:      { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    getList?:         { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    remove?:          { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    save?:            { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    saveList?:        { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    patch?:           { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    patchList?:       { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    merge?:           { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    getAll?:          { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    softRemove?:      { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    restore?:         { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+
+    // Methods that do NOT accept defaultSelect
+    removeList?:      { active?: boolean; ignoreRequiredWhere?: boolean };
+    softRemoveList?:  { active?: boolean; ignoreRequiredWhere?: boolean };
+    restoreList?:     { active?: boolean; ignoreRequiredWhere?: boolean };
+    total?:           { active?: boolean; ignoreRequiredWhere?: boolean };
+    has?:             { active?: boolean; ignoreRequiredWhere?: boolean };
+  };
+});
+```
+
+### `.extend(fn)`
+
+```ts
+repo.extend((repo) => ({
+  myMethod: () => { ... }
+}));
+```
+
+---
+
+## Practical examples
+
+Besides this README, the repository has an **[`examples/`](https://github.com/jaobrabo123/VSRepository/tree/main/examples)** folder with practical, commented, ready-to-run examples — it's the best place to see VSRepository being used in real scenarios.
+
+```text
+examples/
+├── prisma.ts             # PrismaClient instance used by the examples
+├── repositories.ts       # Repository configuration (User, Address, Product) with setupVSRepo
+└── tests/
+    ├── base-methods.test.ts       # Base methods: get, save, patch, remove, getAll, total, has...
+    ├── relations.test.ts          # How to configure and use relations in save/patch and in filters
+    ├── required-where.test.ts     # How requiredWhere is automatically applied to queries
+    ├── dynamic-methods.test.ts    # Prefixes, field filters, logical operators, and pagination/ordering
+    ├── transactions.test.ts       # Transactions with options.db and instance access via repository.prisma
+    ├── soft-delete.test.ts        # Soft-delete: softRemove, softRemoveList, restore, restoreList and SeeMode
+    └── batch-methods.test.ts      # Batch operations: getList, saveList, patchList and merge
+```
+
+Each file in `tests/` is an independent, runnable script (via `tsx`) that demonstrates a specific set of features, with `console.log` at each step so you can follow the result in the terminal. The folder itself has a [README](https://github.com/jaobrabo123/VSRepository/blob/main/examples/README.md) explaining the suggested reading order, how to set up the environment, and how to run the tests.
+
+---
+
+## Contributing
+
+Contributions are welcome! If you found a bug, have an improvement idea, or want to help with the documentation, feel free to get involved (**[GitHub Repository](https://github.com/jaobrabo123/VSRepository)**):
+
+1. **Fork** the project.
+2. Create a new branch with your change: `git checkout -b fixing-bug`.
+3. Push to your branch: `git push origin fixing-bug`.
+4. Open a **Pull Request**.
+
+To report issues or suggest new features, open an **Issue**.
+
+---
+
+## Requirements
+
+- Node.js 18+ (ESM)
+- Prisma
+- TypeScript (optional, but strongly recommended)
+- `"moduleResolution": "bundler"` or `"nodenext"` in tsconfig
+
+Recommended `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020"]
+  }
+}
+```
+
+---
+
+## Troubleshooting
+
+**Generic types not inferred** — Check that `strict: true` and `moduleResolution: "bundler"` or `"nodenext"` are set in `tsconfig.json`.
+
+**Dynamic method doesn't exist at runtime** — The field referenced in the method name must exist in the Prisma model. E.g.: `findByEmail` requires the model to have an `email` field.
+
+**`proxyTo` required** — Names outside the standard patterns (e.g. `searchByEmail`) aren't parsed directly. Use `proxyTo: "findByEmail"` in these cases.
+
+**Select model returns unexpected fields** — Check that the select model defines exactly the fields your TypeScript type expects.
+
+**`selectModel`, `includeModel` and `include` together in the same call** — Not allowed. Only one of the three can be provided per call: if `includeModel` or `include` is provided, the `select` (including `defaultSelectModel`) is ignored and only the `include` is sent to Prisma.
+
+**`includeModel` doesn't appear as a default repository option** — This is expected. Unlike `defaultSelectModel`, there's no `defaultIncludeModel`/`defaultInclude`. An `includeModel` can only be set in the method call, via `options.includeModel`. A raw, ad hoc include can be set via `options.include`, without needing to be registered in `includeModels`.
+
+**`softRemovekName` throws an error at build** — The provided field must be of type `DateTime` in the Prisma schema. Types like `Boolean` or `String` are not accepted.
+
+**`defaultOrdering` isn't being applied** — Check whether the method uses the `Ordered`, `OrderedAndPaginated`, or `PaginatedAndOrdered` suffix, and whether it has `injectOrdering` configured. Both take priority over the default ordering.
+
+**`Distinct` suffix not recognized** — `Distinct` is only resolved on read prefixes (`findMany`, `findFirst`, `findBy`, `existsBy`, etc). In methods like `count`, `createMany`, `updateMany`, or `deleteMany` the suffix is ignored.
+
+**`saveList`/`patchList` with invalid `db`** — The `db` field in these methods only accepts a `DbTransaction` (the return of `prisma.$transaction`), not the main client. Passing the `PrismaClient` directly will cause unexpected behavior.

--- a/generated/vsrepo/docs/README.pt-BR.md
+++ b/generated/vsrepo/docs/README.pt-BR.md
@@ -1,0 +1,1600 @@
+# VSRepository
+
+![npm](https://img.shields.io/npm/v/vsrepo?style=flat-square)
+![NPM License](https://img.shields.io/npm/l/vsrepo?style=flat-square)
+![NPM Downloads](https://img.shields.io/npm/dt/vsrepo?style=flat-square)
+
+🇧🇷 Você está lendo a versão em português. [🇺🇸 Read in English](./README.md)
+
+Biblioteca de repository pattern para projetos que usam **Prisma**, com suporte completo a **TypeScript** e **inferência de tipos** automática.
+
+O VSRepository permite criar repositórios fortemente tipados com:
+
+- **Métodos base** automáticos: `get`, `getOrThrow`, `getList`, `save`, `saveList`, `remove`, `removeList`, `patch`, `patchList`, `merge`, `getAll`, `total`, `has`
+- **Soft-delete nativo**: `softRemove`, `softRemoveList`, `restore`, `restoreList`
+- **Métodos dinâmicos** inferidos pelo nome: `findOneByEmail`, `findManyPaginated`, `updateById`, `deleteManyByNameStartsWith`
+- **Select models** reutilizáveis para diferentes projeções de dados
+- **Type safety** em 100% das operações
+- **Transações** nativas do Prisma (automáticas em `saveList` e `patchList`)
+- **Extensibilidade** com métodos customizados
+
+> 💡 Quer ver tudo isso na prática? A pasta [`examples/`](https://github.com/jaobrabo123/VSRepository/tree/main/examples) do repositório tem exemplos comentados e executáveis para cada funcionalidade — veja a seção [Exemplos práticos](#exemplos-práticos) mais abaixo.
+
+---
+
+## Sumário
+
+- [Instalação](#instalação)
+- [Gerando os tipos](#gerando-os-tipos)
+- [Uso básico](#uso-básico)
+- [Abordagem baseada em classes (DynamicRepository)](#abordagem-baseada-em-classes-dynamicrepository)
+- [Integração com NestJS](#integração-com-nestjs)
+- [Métodos base](#métodos-base)
+  - [Soft-delete](#soft-delete)
+  - [Operações em lote](#operações-em-lote)
+  - [Merge](#merge)
+  - [Configurando os métodos base](#configurando-os-métodos-base)
+- [Select Models](#select-models)
+  - [Select bruto (options.select)](#select-bruto-optionsselect)
+- [Include Models](#include-models)
+  - [Include bruto (options.include)](#include-bruto-optionsinclude)
+- [Required Where](#required-where)
+- [Ordenação padrão (Default Ordering)](#ordenação-padrão-default-ordering)
+- [Opção `see`](#opção-see)
+- [Métodos dinâmicos](#métodos-dinâmicos)
+  - [Prefixos disponíveis](#prefixos-disponíveis)
+  - [Filtros de campo](#filtros-de-campo)
+  - [Operadores lógicos](#operadores-lógicos)
+  - [Filtros de relação](#filtros-de-relação)
+  - [Sufixos de paginação e ordenação](#sufixos-de-paginação-e-ordenação)
+  - [Distinct](#distinct)
+  - [Configuração de método](#configuração-de-método)
+  - [Aggregate e GroupBy](#aggregate-e-groupby)
+  - [Query Methods](#query-methods)
+- [Relações no save](#relações-no-save)
+- [Transações](#transações)
+- [Estendendo um repositório](#estendendo-um-repositório)
+- [Tratamento de erros](#tratamento-de-erros)
+- [Tipos utilitários](#tipos-utilitários)
+- [Referência da API](#referência-da-api)
+- [Exemplos práticos](#exemplos-práticos)
+- [Contribuindo](#contribuindo)
+- [Requisitos](#requisitos)
+- [Solução de problemas](#solução-de-problemas)
+
+---
+
+## Instalação
+
+```bash
+npm i vsrepo @prisma/client
+```
+
+Gere o Prisma Client:
+
+```bash
+npx prisma generate
+```
+
+---
+
+## Gerando os tipos
+
+O VSRepository precisa saber o caminho real do seu Prisma Client para gerar as tipagens corretamente.
+
+```bash
+npx vsrepo generate
+```
+
+Equivalente a:
+
+```bash
+npx vsrepo generate \
+  --output generated/vsrepo \
+  --prisma generated/prisma
+```
+
+**Flags disponíveis:**
+
+| Flag       | Atalho | Padrão               |
+| ---------- | ------ | -------------------- |
+| `--output` | `-o`   | `generated/vsrepo`   |
+| `--prisma` | `-p`   | `generated/prisma`   |
+
+**Arquivos gerados:**
+
+```text
+generated/vsrepo/
+├── DynamicRepository.ts
+├── DynamicRepository.types.d.ts
+├── VSRepoError.ts
+├── VSRepoError.types.d.ts
+├── VSRepository.ts
+├── VSRepository.types.d.ts
+└── index.ts
+```
+
+Depois de gerar, sempre importe a partir da pasta gerada:
+
+```ts
+// CORRETO ✅
+import { setupVSRepo } from "../../generated/vsrepo";
+
+// ERRADO ❌
+import { setupVSRepo } from "vsrepo";
+```
+
+---
+
+## Uso básico
+
+### Configurando o Prisma Client
+
+```ts
+// src/configs/db.ts
+import { PrismaClient } from '../../generated/prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import 'dotenv/config';
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+const prisma = new PrismaClient({ adapter });
+
+export default prisma;
+```
+
+### Criando um repositório
+
+```ts
+// src/repositories/userRepository.ts
+import prisma from "../configs/db";
+import { setupVSRepo } from "../../generated/vsrepo";
+import type { User } from "../../generated/prisma/client";
+
+const userRepository = setupVSRepo<User, "User">()(({
+  tableName: "user",
+  pkName: "id",
+  selectModels: {
+    public: { id: true, name: true, email: true },
+  },
+  defaultSelectModel: "public",
+}).build(prisma);
+
+export default userRepository;
+```
+
+### Usando o repositório
+
+```ts
+import userRepository from "./repositories/userRepository";
+
+const user = await userRepository.save({
+  name: "John",
+  email: "john@email.com",
+  password: "password",
+});
+
+const found = await userRepository.get(user.id);
+const all = await userRepository.getAll();
+
+user.name = "John Smith";
+
+await userRepository.save(user);
+await userRepository.remove(user.id);
+```
+
+---
+
+## Abordagem baseada em classes (DynamicRepository)
+
+Se você prefere um estilo OOP com decorators em vez da abordagem funcional `setupVSRepo`, o VSRepository também oferece `DynamicRepository` — uma classe que você pode estender com decorators `@DynamicMethod()` para definir seus métodos dinâmicos.
+
+Veja **[README-DynamicRepo.pt-BR.md](./README-DynamicRepo.pt-BR.md)** para a documentação completa da abordagem baseada em classes, incluindo exemplos de integração com NestJS, configuração de decorators e uma comparação com o `setupVSRepo`.
+
+---
+
+## Integração com NestJS
+
+O VSRepository pode ser facilmente integrado a projetos NestJS através de providers. Abaixo está um exemplo completo usando o padrão de injeção de dependência do NestJS.
+
+### Configurando o repositório como provider
+
+```ts
+// src/modules/user/user.repository.ts
+import { Provider } from "@nestjs/common";
+import { PrismaService } from "../../database/prisma.service";
+import { UserGetPayload } from "../../../generated/prisma/models";
+import { setupVSRepo } from "../../../generated/vsrepo";
+
+const userVSRepo = setupVSRepo<
+    UserGetPayload<{ include: { profile: true } }>,
+    "User"
+>()(({
+    tableName: "user",
+    pkName: "id",
+    selectModels: {
+        public: {
+            id: true,
+            email: true,
+            createdAt: true,
+            updatedAt: true,
+        },
+        auth: {
+            id: true,
+            email: true,
+            password: true,
+        },
+    },
+    defaultSelectModel: "public",
+    requiredWhere: {
+        deletedAt: null,
+    },
+    relations: {
+        profile: {
+            mode: "oto",
+            pk: "id",
+            restriction: "add",
+        },
+    },
+    methods: {
+        findAuthByEmail: {
+            map: true,
+            proxyTo: "findUniqueByEmail",
+            selectModel: "auth",
+        },
+        findByEmailEndsWith: {
+            map: true,
+        }
+    },
+});
+
+const setupUserRepository = (prisma: PrismaService) => {
+    return userVSRepo.build(prisma);
+};
+
+export type UserRepository = ReturnType<typeof setupUserRepository>;
+/* 
+O tipo também pode ser inferido usando o `RepositoryOf` do VSRepository, passando o tipo de `userVSRepo`:
+
+export type UserRepository = RepositoryOf<typeof userVSRepo>;
+
+OBS: Se você usar `.extend` para estender o repositório ou configurar os métodos base,
+usar `ReturnType` é recomendado por ser mais simples de inferir o tipo
+*/
+
+export const USER_REPOSITORY = Symbol("USER_REPOSITORY");
+
+export const UserRepositoryProvider: Provider = {
+    provide: USER_REPOSITORY,
+    inject: [PrismaService],
+    useFactory: setupUserRepository,
+};
+```
+
+### Registrando o provider no módulo
+
+```ts
+// src/modules/user/user.module.ts
+import { Module } from "@nestjs/common";
+import { UserRepositoryProvider } from "./user.repository";
+import { UserService } from "./user.service";
+import { UserController } from "./user.controller";
+
+@Module({
+    imports: [DatabaseModule],
+    providers: [UserRepositoryProvider, UserService],
+    controllers: [UserController],
+    exports: [UserService],
+})
+export class UserModule {}
+```
+
+### Usando o repositório em um service
+
+```ts
+// src/modules/user/user.service.ts
+import { Injectable, Inject } from "@nestjs/common";
+import { USER_REPOSITORY, type UserRepository } from "./user.repository";
+
+@Injectable()
+export class UserService {
+    constructor(
+        @Inject(USER_REPOSITORY)
+        private readonly userRepository: UserRepository,
+    ) {}
+
+    async getUserById(id: string) {
+        return this.userRepository.get(id);
+    }
+
+    async getUserAuthByEmail(email: string) {
+        return this.userRepository.findAuthByEmail(email);
+    }
+
+    async createUser(data: { email: string; password: string; name: string }) {
+        return this.userRepository.save({
+            email: data.email,
+            password: data.password,
+            name: data.name,
+        });
+    }
+}
+```
+
+**Benefícios dessa abordagem:**
+
+- ✅ Repositórios type-safe com injeção de dependência
+- ✅ Fácil de testar (mock do `USER_REPOSITORY`)
+- ✅ Isolamento da lógica de persistência
+- ✅ Reuso do repositório em múltiplos services
+- ✅ Suporte a transações via `PrismaService`
+
+---
+
+## Métodos base
+
+Ao chamar `.build(prisma)`, os métodos base abaixo ficam automaticamente disponíveis:
+
+| Método                    | Descrição                                                                                                      |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `get(pk)`                 | Busca um registro pela sua chave primária                                                                      |
+| `getOrThrow(pk)`          | Busca um registro pela sua chave primária; lança `VSRepoRuntimeError` (código `"20727"`) se não for encontrado |
+| `getList(pks)`            | Busca múltiplos registros a partir de uma lista de chaves primárias                                            |
+| `save(obj)`               | Cria ou atualiza — se o objeto tiver uma `pk`, realiza um `upsert`; caso contrário, um `create`                |
+| `saveList(objs)`          | Salva um array de objetos em uma única transação automática                                                    |
+| `patch(pk, obj)`          | Atualiza parcialmente um registro pela sua chave primária                                                      |
+| `patchList(tuples)`       | Atualiza parcialmente múltiplos registros via um array de tuplas `[pk, obj]` em uma transação automática       |
+| `merge(pk, obj)`          | Busca um registro e faz um deep merge em memória — **não persiste**, retorna o objeto mesclado                 |
+| `remove(pk)`              | Remove um registro pela sua chave primária                                                                     |
+| `removeList(pks)`         | Remove vários registros a partir de uma lista de chaves primárias — retorna `{ count }`                        |
+| `getAll()`                | Retorna todos os registros (aceita `pagination` e `order` em `options`)                                        |
+| `total()`                 | Retorna o número total de registros                                                                            |
+| `has(pk)`                 | Verifica se um registro existe pela sua chave primária — retorna `boolean`                                     |
+
+Todos eles aceitam `options` como último argumento.
+
+### Soft-delete
+
+Quando `softRemovekName` está configurado no repositório, os métodos adicionais abaixo ficam disponíveis:
+
+| Método                      | Descrição                                                                          |
+| --------------------------- | ---------------------------------------------------------------------------------- |
+| `softRemove(pk)`            | Marca um registro como removido, preenchendo `softRemovekName` com a data atual    |
+| `softRemoveList(pks)`       | Marca múltiplos registros como removidos em lote — retorna `{ count }`             |
+| `restore(pk)`               | Restaura um registro com soft-delete, limpando o campo `softRemovekName`           |
+| `restoreList(pks)`          | Restaura múltiplos registros com soft-delete em lote — retorna `{ count }`         |
+
+```ts
+const userRepository = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+  softRemovekName: "deletedAt", // deve ser um campo DateTime no schema do Prisma
+}).build(prisma);
+
+await userRepository.softRemove(1);
+await userRepository.restore(1);
+```
+
+> O campo informado em `softRemovekName` **deve** ser do tipo `DateTime` no schema do Prisma. O VSRepository valida isso no momento do `build` e lança `VSRepoBuildError` se o tipo estiver incorreto.
+
+### Operações em lote
+
+`saveList` e `patchList` executam automaticamente todas as operações dentro de uma única transação do Prisma. Se alguma operação falhar, todas as anteriores são desfeitas (rollback).
+
+```ts
+// saveList — cria ou atualiza múltiplos objetos em uma transação automática
+const users = await userRepository.saveList([
+  { name: "Mary", email: "mary@email.com" },
+  { id: 2, name: "John Updated", email: "john@email.com" },
+]);
+
+// patchList — atualiza parcialmente múltiplos registros via tuplas [pk, obj]
+const updated = await userRepository.patchList([
+  [1, { active: false }],
+  [2, { name: "New Name" }],
+]);
+```
+
+Quando você já está dentro de uma transação existente, passe-a em `options.db`. Nesse caso, `db` deve ser um `DbTransaction` (não o client principal):
+
+```ts
+await prisma.$transaction(async (tx) => {
+  await userRepository.saveList([{ name: "Mary" }, { name: "Gus" }], { db: tx });
+  await userRepository.patchList([[1, { active: false }], [2, { active: true }]], { db: tx });
+});
+```
+
+### Merge
+
+O método `merge` busca um registro pela PK e faz um deep merge (`deepmerge`) do objeto informado com os dados existentes **em memória**. Ele **não persiste** as alterações — retorna o resultado mesclado para que você decida o que fazer com ele.
+
+```ts
+const existing = await userRepository.get(1);
+// existing: { id: 1, name: "Mary", profile: { bio: "Hi", age: 25 } }
+
+const merged = await userRepository.merge(1, {
+  profile: { bio: "Updated bio" },
+});
+// merged: { id: 1, name: "Mary", profile: { bio: "Updated bio", age: 25 } }
+
+// Para persistir, passe para save ou patch:
+await userRepository.save(merged);
+```
+
+Retorna `null` se o registro não for encontrado.
+
+**O merge de relações to-many (`otm`/`mtm`) é feito por PK, não por simples concatenação.** Para relações to-one (`oto`/`mto`), o `merge` faz um deep merge comum do objeto. Para relações to-many, cada item do array enviado é comparado com o item existente que tem a mesma PK (definida em `relations[key].pk`): se a PK bater, os dois objetos são mesclados; se não bater (um item novo, sem correspondente), ele é simplesmente adicionado à lista. Itens existentes que não aparecem no array enviado são mantidos.
+
+```ts
+const existing = await userRepository.get(1);
+// existing: {
+//   id: 1,
+//   posts: [
+//     { id: 10, title: "Post A", published: false },
+//     { id: 11, title: "Post B", published: true },
+//   ],
+// }
+
+const merged = await userRepository.merge(1, {
+  posts: [
+    { id: 10, published: true },  // mesma PK (id: 10) → mescla com o item existente
+    { title: "Post C" },          // sem PK → adicionado como novo item
+  ],
+});
+// merged: {
+//   id: 1,
+//   posts: [
+//     { id: 10, title: "Post A", published: true },  // mesclado
+//     { id: 11, title: "Post B", published: true },  // mantido, não estava no array enviado
+//     { title: "Post C" },                            // adicionado
+//   ],
+// }
+```
+
+> Observe que o `merge` nunca remove itens de uma relação to-many — ele apenas mescla os que batem por PK e adiciona os que não batem. Para remover itens de uma relação, use `save`/`patch` com `restriction: "set"` na configuração da relação.
+
+### Configurando os métodos base
+
+O segundo argumento de `.build(prisma, config)` permite ajustar o comportamento global do repositório e customizar cada método base individualmente através de `baseMethods`.
+
+```ts
+userVSRepo.build(prisma, {
+  // Exibe os logs internos do VSRepository no console (queries montadas, prefixo
+  // detectado, filtros aplicados, etc). Ótimo para debugar métodos dinâmicos. Padrão = false.
+  showWorking: true,
+
+  baseMethods: {
+    get: {
+      // Habilita/desabilita o método no repositório final. Se `false`, o método
+      // nem aparece no tipo do repositório (não é apenas um erro em runtime). Padrão = true.
+      active: true,
+
+      // Select model aplicado por padrão quando o método é chamado sem `options.selectModel`.
+      // Sobrescreve o `defaultSelectModel` de setupVSRepo apenas para este método.
+      defaultSelect: "public",
+    },
+    remove: {
+      active: true,
+      defaultSelect: "minimal",
+
+      // Quando `true`, ignora o `requiredWhere` configurado em setupVSRepo para
+      // este método específico — útil quando um método precisa "furar" um
+      // filtro global (ex: multi-tenancy) em um caso específico. Padrão = false.
+      ignoreRequiredWhere: false,
+    },
+    save: {
+      // Aqui apenas `ignoreRequiredWhere` é definido — `active` e `defaultSelect`
+      // mantêm seus padrões (true e o `defaultSelectModel` global).
+      ignoreRequiredWhere: true,
+    },
+    patch: {
+      // Apenas o select é sobrescrito; o método continua ativo normalmente.
+      defaultSelect: "minimal",
+    },
+    has: {
+      active: false, // Desabilita 'has' (padrão = true) — o método desaparece do repositório
+    },
+    softRemove: {
+      // Métodos de soft-delete seguem as mesmas opções (`active`, `defaultSelect`,
+      // `ignoreRequiredWhere`). Só estão disponíveis se `softRemovekName` estiver configurado.
+      active: true,
+      defaultSelect: "minimal",
+    },
+  },
+});
+```
+
+> Métodos de lote/agregação como `removeList`, `softRemoveList`, `restoreList`, `total` e `has` **não** aceitam `defaultSelect` (eles não retornam um registro selecionável — retornam `{ count }` ou `boolean`). Nesses casos, `BaseMethodConfig` fica restrito a `active` e `ignoreRequiredWhere`.
+
+---
+
+## Select Models
+
+`selectModels` define projeções de dados nomeadas e reutilizáveis.
+
+```ts
+selectModels: {
+  public:   { id: true, name: true, email: true },
+  internal: { id: true, name: true, email: true, password: true },
+  minimal:  { id: true },
+},
+defaultSelectModel: "public",
+```
+
+`defaultSelectModel` define qual select é usado automaticamente quando nenhum é especificado na chamada. É recomendado sempre defini-lo junto com `selectModels`.
+
+**Usando um select específico na chamada:**
+
+```ts
+const user = await userRepository.get(id, { selectModel: "minimal" });
+```
+
+**Retornando o payload padrão do Prisma (sem select):**
+
+```ts
+const fullUser = await userRepository.get(id, { selectModel: false });
+```
+
+### Select bruto (`options.select`)
+
+Além do `selectModel` (nomeado, pré-configurado em `selectModels`), você pode passar um `select` bruto do Prisma diretamente na chamada, sem precisar registrá-lo antecipadamente no repositório.
+
+```ts
+const usuario = await usuarioRepository.get(id, {
+  select: { id: true, nome: true },
+});
+```
+
+`options.select` aceita qualquer `select` válido para o modelo Prisma do repositório — é totalmente tipado e oferece o mesmo autocomplete/validação de chamar `prisma.usuario.findMany({ select: ... })` diretamente, e o tipo de retorno do método é restrito exatamente aos campos selecionados.
+
+**Regras e comportamento:**
+
+- **Mutuamente exclusivo com `selectModel`, `includeModel` e `include`.** Apenas um dos quatro pode ser fornecido por chamada; os tipos garantem isso — passar mais de um é um erro em tempo de compilação.
+- **Ad hoc, não reutilizável.** Diferente do `selectModel`, não precisa ser declarado em `selectModels`. Use-o para projeções pontuais que não justificam um select model nomeado.
+- **Nenhum `defaultSelectModel` é aplicado.** Quando `select` é fornecido, o select padrão (`defaultSelectModel`) é ignorado e apenas o `select` bruto é enviado ao Prisma.
+
+```ts
+// CORRETO ✅ — apenas select bruto
+await usuarioRepository.get(id, { select: { id: true, nome: true } });
+
+// ERRADO ❌ — combinar select com selectModel/includeModel/include não é permitido
+await usuarioRepository.get(id, { selectModel: "public", select: { id: true } });
+await usuarioRepository.get(id, { include: { posts: true }, select: { id: true } });
+```
+
+> **Quando usar `selectModel` vs. `select`:** prefira `selectModel` para projeções reutilizadas em várias chamadas (definidas uma vez em `selectModels`); use `select` para projeções específicas e ocasionais que não precisam de um nome.
+
+---
+
+## Include Models
+
+`includeModels` funciona de forma parecida com `selectModels`, mas em vez de receber um `select`, recebe um `include` válido do Prisma.
+
+```ts
+const userRepository = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+  selectModels: {
+    public: { id: true, name: true, email: true },
+  },
+  defaultSelectModel: "public",
+  includeModels: {
+    withPosts: { posts: true },
+    withPostsAndProfile: { posts: true, profile: true },
+  },
+}).build(prisma);
+```
+
+**Usando um `includeModel` na chamada:**
+
+```ts
+const user = await userRepository.get(id, { includeModel: "withPosts" });
+```
+
+Nesse caso, o `select` padrão (`selectModels`/`defaultSelectModel`) é ignorado e apenas o `include` é enviado ao Prisma.
+
+### Diferenças em relação a `selectModels`
+
+- **Só pode ser passado na chamada do método**, via `options.includeModel`. Não existe `defaultIncludeModel` ou `defaultInclude` — não há como configurar um `includeModel` padrão no repositório, ao contrário do que acontece com `defaultSelectModel`.
+- **`includeModel` e `selectModel` não podem ser passados juntos** na mesma chamada. Se um `includeModel` for informado, qualquer `selectModel` (incluindo o padrão) é ignorado.
+
+```ts
+// CORRETO ✅ — apenas includeModel
+await userRepository.get(id, { includeModel: "withPosts" });
+
+// CORRETO ✅ — apenas selectModel
+await userRepository.get(id, { selectModel: "public" });
+
+// ERRADO ❌ — combinar os dois não é permitido
+await userRepository.get(id, { selectModel: "public", includeModel: "withPosts" });
+```
+
+### Include bruto (`options.include`)
+
+Além do `includeModel` (nomeado, pré-configurado em `includeModels`), você pode passar um `include` bruto do Prisma diretamente na chamada, sem precisar registrá-lo antes no repositório.
+
+```ts
+const user = await userRepository.get(id, {
+  include: { posts: true, profile: true },
+});
+```
+
+`options.include` aceita qualquer `include` válido para o modelo Prisma do repositório — é totalmente tipado e oferece o mesmo autocomplete/validação de chamar `prisma.user.findMany({ include: ... })` diretamente.
+
+**Regras e comportamento:**
+
+- **Mutuamente exclusivo com `selectModel` e `includeModel`.** Apenas um dos três pode ser informado por chamada; os tipos garantem isso — passar mais de um é um erro em tempo de compilação.
+- **Ad hoc, não reutilizável.** Diferente do `includeModel`, não precisa ser declarado em `includeModels`. Use para includes pontuais que não justificam um model nomeado.
+- **Nenhum `selectModel` padrão é aplicado.** Assim como com `includeModel`, quando `include` é informado, o select (incluindo `defaultSelectModel`) é ignorado e apenas o `include` é enviado ao Prisma.
+
+```ts
+// CORRETO ✅ — apenas include bruto
+await userRepository.get(id, { include: { posts: true } });
+
+// ERRADO ❌ — combinar include com selectModel/includeModel não é permitido
+await userRepository.get(id, { selectModel: "public", include: { posts: true } });
+await userRepository.get(id, { includeModel: "withPosts", include: { posts: true } });
+```
+
+> **Quando usar `includeModel` vs. `include`:** prefira `includeModel` para includes reutilizados em várias chamadas (definidos uma vez em `includeModels`); use `include` para includes específicos e pontuais que não precisam de um nome.
+
+---
+
+## Required Where
+
+`requiredWhere` define filtros que são aplicados automaticamente em toda query do repositório.
+
+```ts
+requiredWhere: { active: true },
+```
+
+Agora toda query vai incluir automaticamente `active: true`:
+
+```ts
+// Internamente: WHERE active = true
+const users = await userRepository.findMany();
+
+// Internamente: WHERE email = 'john@email.com' AND active = true
+const user = await userRepository.findByEmail("john@email.com");
+```
+
+Útil para soft-deletes manuais, multi-tenancy e filtros globais de qualquer tipo.
+
+---
+
+## Ordenação padrão (Default Ordering)
+
+`defaultOrdering` define uma ordenação padrão que é aplicada automaticamente em toda query que aceita `orderBy`, sem precisar repetir o argumento `order` em cada chamada.
+
+```ts
+const userRepository = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+  defaultOrdering: { createdAt: "desc" },
+}).build(prisma);
+```
+
+Com isso, toda query de listagem já virá ordenada por `createdAt` decrescente:
+
+```ts
+// Internamente: ORDER BY createdAt DESC
+const users = await userRepository.getAll();
+
+// Também se aplica ao getAll com paginação
+const paginated = await userRepository.getAll({ pagination: { take: 10 } });
+```
+
+**`defaultOrdering` é ignorado quando:**
+
+- O método usa o sufixo `Ordered`, `OrderedAndPaginated` ou `PaginatedAndOrdered` — nesses casos, o argumento `order` passado na chamada tem prioridade.
+- O método dinâmico tem `injectOrdering` configurado — a ordenação fixa do método tem precedência.
+
+```ts
+methods: {
+  findManyPaginatedAndOrdered: { map: true },         // order vem do argumento → defaultOrdering ignorado
+  findManyByActive:            { map: true },         // sem Ordered → defaultOrdering aplicado
+  findManyByStatus: {
+    map: true,
+    injectOrdering: { name: "asc" },                  // injectOrdering → defaultOrdering ignorado
+  },
+}
+```
+
+> `defaultOrdering` aceita o mesmo tipo do `orderBy` nativo do Prisma para o modelo — incluindo arrays de ordenações encadeadas.
+
+---
+
+## Opção `see`
+
+Quando `softRemovekName` está configurado, todo método aceita a opção `see` para controlar a visibilidade de registros com soft-delete:
+
+| Valor       | Comportamento                                                  |
+| ----------- | -------------------------------------------------------------- |
+| `"active"`  | Retorna apenas registros que **não** foram removidos (padrão)  |
+| `"removed"` | Retorna apenas registros removidos                             |
+| `"all"`     | Retorna todos os registros, independente do status             |
+
+```ts
+// Retorna apenas usuários ativos (padrão)
+const active = await userRepository.getAll();
+
+// Retorna apenas usuários removidos
+const removed = await userRepository.getAll({ see: "removed" });
+
+// Retorna todos
+const all = await userRepository.getAll({ see: "all" });
+```
+
+> A opção `see` funciona independentemente do `requiredWhere` — ela é aplicada em cima do filtro de soft-delete, não como substituta dele.
+
+---
+
+## Métodos dinâmicos
+
+Métodos dinâmicos são definidos na propriedade `methods` e têm seu comportamento inferido pelo nome.
+
+```ts
+methods: {
+  findOneByEmail:     { map: true },
+  findManyPaginated:  { map: true },
+  updateById:         { map: true },
+  deleteManyByIdIn:   { map: true },
+}
+```
+
+---
+
+### Prefixos disponíveis
+
+O prefixo do nome do método determina qual operação do Prisma será chamada e quais argumentos são esperados.
+
+| Prefixo                      | Operação do Prisma          | Retorno                  | Observações                                                                                                      |
+| ---------------------------- | --------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `findOneBy`                  | `findFirst`                 | `T \| null`              | Retorno único.                                                                                                   |
+| `findBy`                     | `findMany` / `findFirst`    | `T[]` ou `T \| null`     | Padrão é lista; use `fbMode: "one"` para retorno único (**deprecated**, use `findOneBy`)                         |
+| `findUniqueBy`               | `findUnique`                | `T \| null`              |                                                                                                                  |
+| `findUniqueOrThrowBy`        | `findUniqueOrThrow`         | `T`                      | Lança um erro se não encontrado                                                                                  |
+| `findFirstBy`                | `findFirst`                 | `T \| null`              | Aceita campos como filtro                                                                                        |
+| `findFirstOrThrowBy`         | `findFirstOrThrow`          | `T`                      | Aceita campos como filtro; lança um erro se não encontrado                                                       |
+| `findFirst`                  | `findFirst`                 | `T \| null`              | Sem filtros de campo; aplica apenas `requiredWhere` e `pushWhere`                                                |
+| `findFirstOrThrow`           | `findFirstOrThrow`          | `T`                      | Sem filtros de campo; aplica apenas `requiredWhere` e `pushWhere`; lança um erro se não encontrado               |
+| `findManyBy`                 | `findMany`                  | `T[]`                    | Aceita campos como filtro                                                                                        |
+| `findMany`                   | `findMany`                  | `T[]`                    | Sem filtros de campo; aplica apenas `requiredWhere` e `pushWhere`                                                |
+| `findOneWhere`               | `findFirst`                 | `T \| null`              | Recebe um objeto `where` explícito como argumento                                                                |
+| `findListWhere`              | `findMany`                  | `T[]`                    | Recebe um objeto `where` explícito como argumento                                                                |
+| `existsBy`                   | `findFirst`                 | `boolean`                | Retorna `true` se encontrado, `false` caso contrário                                                             |
+| `existsWhere`                | `findFirst`                 | `boolean`                | Recebe um objeto `where` explícito e retorna se existe                                                           |
+| `countBy`                    | `count`                     | `number`                 | Aceita campos como filtro                                                                                        |
+| `countWhere`                 | `count`                     | `number`                 | Recebe um objeto `where` explícito como argumento                                                                |
+| `count`                      | `count`                     | `number`                 | Sem filtros de campo; aplica apenas `requiredWhere` e `pushWhere`                                                |
+| `create`                     | `create`                    | `T`                      | Recebe `data` como argumento                                                                                     |
+| `createMany`                 | `createMany`                | `{ count: number }`      | Recebe `data` como argumento; suporta `SkipDuplicates`                                                           |
+| `createManyAndReturn`        | `createManyAndReturn`       | `T[]`                    | Recebe `data` como argumento; suporta `SkipDuplicates`                                                           |
+| `updateBy`                   | `update`                    | `T`                      | Recebe `data` como argumento                                                                                     |
+| `updateManyBy`               | `updateMany`                | `{ count: number }`      | Recebe `data` como argumento                                                                                     |
+| `updateManyWhere`            | `updateMany`                | `{ count: number }`      | Recebe um objeto `where` e um objeto `data` como argumentos                                                      |
+| `updateManyAndReturnBy`      | `updateManyAndReturn`       | `T[]`                    | Recebe `data` como argumento                                                                                     |
+| `updateManyAndReturnWhere`   | `updateManyAndReturn`       | `T[]`                    | Recebe um objeto `where` e um objeto `data` como argumentos                                                      |
+| `upsertBy`                   | `upsert`                    | `T`                      | Recebe `update` e `create` como argumentos                                                                       |
+| `deleteBy`                   | `delete`                    | `T`                      |                                                                                                                  |
+| `deleteManyBy`               | `deleteMany`                | `{ count: number }`      |                                                                                                                  |
+| `deleteManyWhere`            | `deleteMany`                | `{ count: number }`      | Recebe um objeto `where` explícito como argumento                                                                |
+| `aggregate`                  | `aggregate`                 | `Dynamic`                | O nome deve ser exato; recebe argumentos nativos do Prisma; ignora `selectModels`, `pushWhere` e `requiredWhere` |
+| `groupBy`                    | `groupBy`                   | `Dynamic[]`              | O nome deve ser exato; recebe argumentos nativos do Prisma; ignora `selectModels`, `pushWhere` e `requiredWhere` |
+
+---
+
+### Filtros de campo
+
+Filtros são sufixos aplicados ao nome do campo dentro do método. O próprio campo vem capitalizado logo após o prefixo (ou após `By`).
+
+| Sufixo                | Operador Prisma        | Argumento obrigatório       |
+| --------------------- | ---------------------- | --------------------------- |
+| *(sem sufixo)*        | igualdade (`=`)        | sim                         |
+| `Not`                 | `not`                  | sim                         |
+| `In`                  | `in`                   | sim (array)                 |
+| `NotIn`               | `notIn`                | sim (array)                 |
+| `Contains`            | `contains`             | sim                         |
+| `NotContains`         | `not.contains`         | sim                         |
+| `StartsWith`          | `startsWith`           | sim                         |
+| `NotStartsWith`       | `not.startsWith`       | sim                         |
+| `EndsWith`            | `endsWith`             | sim                         |
+| `NotEndsWith`         | `not.endsWith`         | sim                         |
+| `GreaterThan`         | `gt`                   | sim                         |
+| `GreaterThanEqual`    | `gte`                  | sim                         |
+| `LessThan`            | `lt`                   | sim                         |
+| `LessThanEqual`       | `lte`                  | sim                         |
+| `Between`             | `gte` + `lte`          | sim (tupla `[min, max]`)    |
+| `NotBetween`          | `not.gte` + `not.lte`  | sim (tupla `[min, max]`)    |
+| `IsNull`              | `null`                 | não                         |
+| `IsNotNull`           | `not: null`            | não                         |
+| `IsTrue`              | `true`                 | não                         |
+| `IsFalse`             | `false`                | não                         |
+| `Insensitive`         | `mode: 'insensitive'`  | combinador                  |
+
+`Insensitive` é um combinador e pode ser usado junto com outro filtro de texto:
+
+```ts
+findByNameContainsInsensitive    // { name: { contains: value, mode: 'insensitive' } }
+findByEmailStartsWithInsensitive // { email: { startsWith: value, mode: 'insensitive' } }
+findByNameInsensitive            // { name: { equals: value, mode: 'insensitive' } }
+```
+
+`Between` e `NotBetween` recebem uma **tupla `[valorMinimo, valorMaximo]`**:
+
+```ts
+methods: {
+  findManyByAgeBetween:      { map: true },
+  findManyBySalaryNotBetween: { map: true },
+  findManyByCreatedAtBetween: { map: true },
+}
+
+await userRepository.findManyByAgeBetween([18, 65]);
+await userRepository.findManyBySalaryNotBetween([1000, 5000]);
+await userRepository.findManyByCreatedAtBetween([new Date("2024-01-01"), new Date("2024-12-31")]);
+```
+
+O sufixo `Optional` pode ser adicionado a qualquer campo para tornar o argumento opcional:
+
+```ts
+findByNameOptionalAndEmail // name é opcional, email é obrigatório
+```
+
+---
+
+### Operadores lógicos
+
+| Operador  | Uso no nome                      | Exemplo                            |
+| --------- | -------------------------------- | ---------------------------------- |
+| `And`     | entre dois campos                | `findOneByIdAndEmail`              |
+| `Or`      | entre dois campos                | `findByNameOrEmail`                |
+| `AND`     | separa um bloco final de `AND`   | `findByEmailOrNameANDActiveStatus` |
+
+`AND` (em maiúsculas) tem uma regra específica:
+
+- Só pode existir **um** `AND` por método.
+- Todos os campos depois do `AND` são injetados dentro de `AND: []`.
+- Depois de um `AND`, não pode haver um `Or`.
+
+Exemplo:
+
+```ts
+methods: {
+  findOneByIdAndEmail:   { map: true },
+  findByNameOrEmail:  { map: true },
+  findFirstByIdOrEmailAndName: { map: true },
+  findByEmailOrNameANDActiveStatusAndAgeGreaterThan: { map: true }
+}
+
+await userRepository.findOneByIdAndEmail(1, "john@email.com");
+await userRepository.findByNameOrEmail("John", "john@email.com");
+await userRepository.findFirstByIdOrEmailAndName(1, "john@email.com", "John");
+await userRepository.findByEmailOrNameANDActiveStatusAndAgeGreaterThan("john@email.com", "John", true, 17)
+```
+
+Gera (`findOneByIdAndEmail`):
+
+```ts
+{
+  id: 1,
+  email: "john@email.com"
+}
+```
+
+Gera (`findByNameOrEmail`):
+
+```ts
+{
+  OR: [
+    { name: "John" },
+    { email: "john@email.com" }
+  ]
+}
+```
+
+Gera (`findFirstByIdOrEmailAndName`):
+
+```ts
+{
+  OR: [
+    { id: 1 },
+    {
+      email: "john@email.com",
+      name: "John"
+    }
+  ]
+}
+```
+
+Gera (`findByEmailOrNameANDActiveStatusAndAgeGreaterThan`):
+
+```ts
+{
+  OR: [
+    { email: "john@email.com" },
+    { name: "John" }
+  ],
+  AND: [
+    { activeStatus: true },
+    { age: { gt: 17 } }
+  ]
+}
+```
+
+---
+
+### Filtros de relação
+
+Permitem filtrar por campos de modelos relacionados.
+
+> [!IMPORTANT]
+>
+> - **Tipagem de relação**: Para que o TypeScript reconheça os tipos dos campos de relação nos métodos dinâmicos, o tipo genérico da entidade passado para `setupVSRepo` deve incluir as relações estruturadas (ex.: usando o `UserGetPayload<{ include: { profile: true, posts: true } }>` do Prisma).
+> - **Compatibilidade de sufixos**:
+>   - Os sufixos `Some`, `Every` e `None` só funcionam em relações **to-many** (`many-to-many` e `one-to-many`).
+>   - Os sufixos `With` e `Without` só funcionam em relações **to-one** (`one-to-one` e `many-to-one`).
+
+| Sufixo de relação      | Operador Prisma  | Observação                                        |
+| ---------------------- | ---------------- | ------------------------------------------------- |
+| `Some`                 | `some: {}`       | A relação tem *algum* registro                    |
+| `SomeField`            | `some.field`     | Filtra dentro dos registros da relação            |
+| `EveryField`           | `every.field`    | Filtra dentro dos registros da relação            |
+| `None`                 | `none: {}`       | A relação não tem *nenhum* registro               |
+| `NoneField`            | `none.field`     | Filtra dentro dos registros da relação            |
+| `With`                 | `is: {}`         | A relação existe (não é nula)                     |
+| `WithField`            | `is.field`       | Filtra um campo dentro da relação                 |
+| `Without`              | `isNot: {}`      | A relação não existe (é nula)                     |
+| `WithoutField`         | `isNot.field`    | Filtra um campo dentro da relação com negação     |
+
+Considerando `user` com uma relação to-one `profile` e uma relação to-many `posts`:
+
+```ts
+methods: {
+  // to-many (posts)
+  findByPostsSome:                { map: true }, // tem pelo menos um post
+  findByPostsSomeTitle:           { map: true }, // tem pelo menos um post com aquele título
+  findByPostsEveryPublishedIsTrue:{ map: true }, // todos os posts estão publicados
+  findByPostsNone:                { map: true }, // não tem nenhum post
+  findByPostsNoneTitle:           { map: true }, // nenhum post tem aquele título
+
+  // to-one (profile)
+  findByProfileWith:             { map: true }, // tem um profile (não é nulo)
+  findByProfileWithBio:          { map: true }, // tem um profile com aquela bio
+  findByProfileWithout:          { map: true }, // não tem profile (é nulo)
+  findByProfileWithoutBio:       { map: true }, // tem um profile, mas com uma bio diferente da informada
+}
+
+await userRepository.findByPostsSome();
+await userRepository.findByPostsSomeTitle("My first post");
+await userRepository.findByPostsEveryPublishedIsTrue();
+await userRepository.findByPostsNone();
+await userRepository.findByPostsNoneTitle("Draft");
+
+await userRepository.findByProfileWith();
+await userRepository.findByProfileWithBio("Hello, world!");
+await userRepository.findByProfileWithout();
+await userRepository.findByProfileWithoutBio("Old bio");
+```
+
+Gera (`findByPostsSomeTitle`):
+
+```ts
+{
+  posts: {
+    some: { title: "My first post" }
+  }
+}
+```
+
+Gera (`findByPostsEveryPublishedIsTrue`):
+
+```ts
+{
+  posts: {
+    every: { published: true }
+  }
+}
+```
+
+Gera (`findByProfileWithBio`):
+
+```ts
+{
+  profile: {
+    is: { bio: "Hello, world!" }
+  }
+}
+```
+
+Gera (`findByProfileWithout`):
+
+```ts
+{
+  profile: {
+    isNot: {}
+  }
+}
+```
+
+> `Some`, `None`, `With` e `Without` (sem campo) não recebem argumento — toda a relação é testada quanto à existência de registros (`some`/`none`) ou quanto a ser `null`/não `null` (`is`/`isNot`). As variantes `SomeField`, `EveryField`, `NoneField`, `WithField` e `WithoutField` recebem como argumento o valor do campo filtrado.
+
+---
+
+### Sufixos de paginação e ordenação
+
+Aplicados no **final** do nome do método, injetam automaticamente os argumentos de paginação e ordenação.
+
+| Sufixo                   | Argumentos adicionais        |
+| ------------------------ | ---------------------------- |
+| `Paginated`              | `(pagination)`               |
+| `Ordered`                | `(order)`                    |
+| `OrderedAndPaginated`    | `(order, pagination)`        |
+| `PaginatedAndOrdered`    | `(pagination, order)`        |
+
+Para `createMany` e `createManyAndReturn`, o sufixo `SkipDuplicates` está disponível:
+
+| Sufixo               | Efeito                                         |
+| ---------------------| ---------------------------------------------- |
+| `SkipDuplicates`     | Ignora registros duplicados durante a inserção |
+
+---
+
+### Distinct
+
+O sufixo `Distinct` permite obter apenas registros únicos com base em um ou mais campos, equivalente à opção `distinct` do Prisma.
+
+Para usá-lo, coloque `Distinct` no nome do método (depois dos filtros de campo, se houver), seguido dos campos desejados separados por `And`. A primeira letra de cada campo deve ser maiúscula, assim como nos filtros de campo comuns.
+
+```ts
+methods: {
+    // Retorna usuários únicos combinando "age" e "role" (sem filtro de campo)
+    findManyDistinctAgeAndRole: { map: true },
+
+    // Distinct combinado com o sufixo Paginated
+    findManyDistinctNamePaginated: { map: true },
+
+    // Distinct combinado com um filtro de campo (name) — filtra por name e depois aplica distinct em role
+    findManyByNameDistinctRole: { map: true },
+},
+```
+
+```ts
+// Sem argumentos: os campos distinct já estão fixados no nome do método
+await userRepository.findManyDistinctAgeAndRole();
+
+// O argumento de paginação continua funcionando normalmente
+await userRepository.findManyDistinctNamePaginated({ take: 10, skip: 0 });
+
+// O filtro do campo "name" continua sendo passado normalmente como argumento
+await userRepository.findManyByNameDistinctRole("John");
+```
+
+> Os campos especificados depois de `Distinct` são resolvidos a partir do nome do método em tempo de build — eles **não** se tornam argumentos em tempo de execução, diferente dos filtros de campo comuns.
+
+`Distinct` está disponível nos prefixos que leem múltiplos ou um único registro: `findMany`, `findManyBy`, `findFirst`, `findFirstBy`, `findFirstOrThrow`, `findFirstOrThrowBy`, `findBy`, `findOneBy`, `findWhere`, `findOneWhere`, `findListWhere`, `existsBy` e `existsWhere`.
+
+---
+
+### Configuração de método
+
+Cada entrada em `methods` aceita as seguintes opções:
+
+| Opção                 | Tipo                                     | Padrão         | Descrição                                                                                                                           |
+| --------------------- | ---------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `map`                 | `boolean`                                | —              | **Obrigatório.** Define se o método será exposto no repositório.                                                                    |
+| `whereType`           | `'extending'` \| `'overwrite'`           | `extending`    | `extending` combina com `requiredWhere`. `overwrite` ignora `requiredWhere`.                                                        |
+| `selectModel`         | `keyof SelectModels \| false`            | —              | Sobrescreve o `defaultSelectModel` para este método.                                                                                |
+| `fbMode`              | `'one'` \| `'list'`                      | `'list'`       | (**Deprecated. Use `findOneBy`**) Apenas para `findBy`. `'one'` retorna `T \| null`; `'list'` retorna `T[]`.                        |
+| `proxyTo`             | `Padrão de método válido`                | —              | Delega a lógica para outro padrão de método válido.                                                                                 |
+| `pushWhere`           | `WhereModel<M>`                          | —              | `where` extra adicionado à query além do `requiredWhere`.                                                                           |
+| `injectOrdering`      | `OrderingModel<M>`                       | —              | Ordenação fixa injetada automaticamente na query.                                                                                   |
+| `injectPagination`    | `PaginationModel<M>`                     | —              | Paginação fixa injetada automaticamente na query.                                                                                   |
+| `query`               | `{ value: string; modifying?: boolean }` | —              | Transforma o método em um **Query Method** (SQL bruto). Ignora todas as outras opções acima — veja [Query Methods](#query-methods). |
+
+---
+
+### Aggregate e GroupBy
+
+```ts
+const userRepository = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+  methods: {
+    aggregate: { map: true },
+    groupBy: { map: true },
+  },
+}).build(prisma);
+```
+
+> [!NOTE]
+> Esses métodos devem ter exatamente esses nomes (`aggregate` e `groupBy`).
+> Diferente dos demais métodos dinâmicos, eles recebem argumentos nativos do Prisma e **ignoram** as configurações `selectModels`, `pushWhere` e `requiredWhere`.
+
+---
+
+### Query Methods
+
+Query Methods permitem que um método execute **SQL bruto** diretamente, contornando totalmente o parser de nomes dos métodos dinâmicos. São úteis para consultas complexas (joins pesados, CTEs, funções específicas do banco) que não são práticas de expressar com os prefixos/sufixos padrão.
+
+Internamente, o VSRepository executa a SQL através do Prisma usando `$queryRawUnsafe` (para leitura) ou `$executeRawUnsafe` (para escrita), e os valores do array `args` são passados como **parâmetros posicionais** (`$1`, `$2`, ...) — a mesma técnica de *prepared statements* usada pelo próprio Prisma. Isso significa que os valores nunca são concatenados na string SQL, o que é o que efetivamente previne SQL Injection.
+
+> [!WARNING]
+> `$1`, `$2`, ... na sua SQL devem representar sempre **valores** (parâmetros de dados), nunca nomes de colunas, tabelas ou trechos de SQL dinâmicos. Nomes de identificadores (colunas/tabelas) não podem ser passados como parâmetro posicional — se seu método precisar variar isso, monte o SQL a partir de um conjunto fixo e conhecido de opções no seu próprio código, nunca a partir de entrada não confiável.
+
+```ts
+const userRepository = setupVSRepo<User, "user">()({
+  tableName: "user",
+  pkName: "id",
+  methods: {
+    // Query method de leitura (não-modifying)
+    findActiveUsersRaw: {
+      map: true,
+      query: {
+        value: 'SELECT * FROM "user" WHERE active = $1',
+      },
+    },
+
+    // Query method de escrita (modifying: true)
+    deactivateUsersOlderThanRaw: {
+      map: true,
+      query: {
+        value: 'UPDATE "user" SET active = false WHERE "createdAt" < $1',
+        modifying: true,
+      },
+    },
+  },
+}).build(prisma);
+```
+
+**Chamando um Query Method:**
+
+Todo Query Method recebe um único argumento no formato `{ args: [...], db? }`:
+
+```ts
+// Não-modifying: retorna 'any' por padrão, mas aceita um generic para
+// inferir/afirmar o tipo de retorno na própria chamada
+const usuariosAtivos = await userRepository.findActiveUsersRaw<User[]>({
+  args: [true],
+});
+
+// Modifying: sempre retorna 'number' (quantidade de linhas afetadas)
+const afetados = await userRepository.deactivateUsersOlderThanRaw({
+  args: [new Date("2024-01-01")],
+});
+
+// Participando de uma transação, via 'db'
+await userRepository.prisma.$transaction(async (tx) => {
+  await userRepository.deactivateUsersOlderThanRaw({
+    args: [new Date("2024-01-01")],
+    db: tx,
+  });
+});
+```
+
+| Opção         | Tipo      | Padrão  | Descrição                                                                                                                                                                                                                     |
+| ------------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value`       | `string`  | —       | **Obrigatório.** SQL bruto a ser executado. Use `$1`, `$2`, ... para os placeholders dos valores em `args`.                                                                                                                   |
+| `modifying`   | `boolean` | `false` | Quando `true`, executa via `$executeRawUnsafe` e o método sempre resolve para `number`. Quando `false`, executa via `$queryRawUnsafe` e o método resolve para `TReturn` (`any` por padrão, inferível via generic na chamada). |
+
+> [!NOTE]
+> Diferente dos demais métodos dinâmicos, Query Methods **ignoram completamente** `selectModels`, `requiredWhere`, `pushWhere`, `whereType`, `injectOrdering`, `injectPagination` e `proxyTo` — nada disso se aplica, já que não há parsing de nome nem montagem de `where`/`select` pelo VSRepository. Nomes de métodos livres (fora dos padrões de `findBy`, `updateBy`, etc.) também **não** exigem `proxyTo`.
+
+A mesma funcionalidade está disponível na abordagem baseada em classes através do decorator `@QueryMethod` — veja o [README-DynamicRepo.pt-BR.md](./README-DynamicRepo.pt-BR.md#o-decorator-querymethod).
+
+---
+
+## Relações no save
+
+Configure as relações para que `save` e `patch` as gerenciem automaticamente (`saveList` e `patchList` também gerenciam relações automaticamente).
+
+```ts
+import type { Prisma } from "../../generated/prisma/client";
+
+type User = Prisma.userGetPayload<{
+  include: { profile: true; posts: true };
+}>;
+
+const userRepository = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+
+  relations: {
+    profile: {
+      pk: "id",
+      mode: "oto",
+      restriction: "set",
+    },
+    posts: {
+      pk: "id",
+      mode: "otm",
+      restriction: "add",
+    },
+  },
+}).build(prisma);
+```
+
+**Modos de relação:**
+
+| Modo  | Relação            |
+| ----- | ------------------ |
+| `oto` | um-para-um         |
+| `otm` | um-para-muitos     |
+| `mto` | muitos-para-um     |
+| `mtm` | muitos-para-muitos |
+
+**Restrições:**
+
+| Restrição   | Comportamento na atualização                                |
+| ----------- | ----------------------------------------------------------- |
+| `set`       | Substitui totalmente (remove os que não foram enviados)     |
+| `add`       | Adiciona/atualiza sem remover os existentes                 |
+
+> [!WARNING]
+> **`set` significa coisas diferentes dependendo do `mode` da relação — e isso pode causar perda de dados se você não tomar cuidado.**
+>
+> Em relações onde o registro relacionado **pertence** ao registro pai (`oto` e `otm`), "remover os que não foram enviados" significa **apagar o registro do banco de dados** (`delete`/`deleteMany`). Em relações onde o registro relacionado é **independente** (`mto` e `mtm`), "remover" significa apenas **desvincular** (`disconnect`/`set: []`) — o registro relacionado continua existindo no banco, apenas deixa de apontar para o pai (ou de estar na tabela de junção).
+>
+> | Modo | `restriction: "set"` quando um item é omitido | O item continua existindo no banco de dados? |
+> | ----- | ------------------------------------------------ | ----------------------------------------------------- |
+> | `oto` | Passar `null` no campo → **apaga** o registro relacionado (`delete: true`) | Não |
+> | `otm` | Itens fora da lista enviada → **apagados** (`deleteMany` com `notIn`) | Não |
+> | `mto` | Passar `null` no campo (com `nullable: true`) → **desvincula** (`disconnect: true`) | Sim |
+> | `mtm` | Itens fora da lista enviada → **desvinculados** da tabela de junção (`set: []`) | Sim |
+>
+> Exemplo prático: se `posts` for `otm` com `restriction: "set"`, um `save`/`patch` que envia o usuário com apenas 2 dos 5 posts existentes vai **apagar os outros 3 posts do banco de dados**, não apenas desvinculá-los do usuário. Se o comportamento esperado for apenas desvincular sem apagar, use `restriction: "add"` (que nunca remove nada) e trate a remoção manualmente.
+
+**Relação `mto` com nullable:**
+
+Use `nullable` (minúsculo) para permitir desvincular uma relação many-to-one:
+
+```ts
+relations: {
+  category: {
+    pk: "id",
+    mode: "mto",
+    restriction: "set",
+    nullable: true, // permite passar null para desvincular
+  },
+}
+```
+
+---
+
+## Transações
+
+Todos os métodos aceitam `options.db` para participar de uma transação:
+
+```ts
+await userRepository.prisma.$transaction(async (tx) => {
+  const user = await userRepository.save(
+    { name: "Mary", email: "mary@email.com", password: "password" },
+    { db: tx }
+  );
+
+  await userLogsRepository.save(
+    { action: "User registration", data: { registeredUser: user.id } },
+    { db: tx }
+  );
+});
+```
+
+Para `saveList` e `patchList`, o campo `db` deve ser um `DbTransaction`:
+
+```ts
+await prisma.$transaction(async (tx) => {
+  // CORRETO: tx é um DbTransaction
+  const registeredUsers = await userRepository.saveList([{ name: "Mary" }, { name: "Lucas" }], { db: tx });
+
+  await userLogsRepository.save(
+    { action: "User registration", data: { registeredUsers: registeredUsers.map(u => u.id) } },
+    { db: tx }
+  );
+});
+```
+
+---
+
+## Estendendo um repositório
+
+```ts
+const userRepository = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+  methods: {
+    findOneByEmailEndsWith: { map: true },
+  },
+})
+  .build(prisma)
+  .extend((repo) => ({
+    findActiveByDomain: async (domain: string) => {
+      return repo.findOneByEmailEndsWith(`@${domain}`);
+    },
+
+    activateMultiple: async (ids: string[]) => {
+      return repo.patchList(ids.map(id => [id, { active: true }]));
+    },
+  }));
+```
+
+---
+
+## Tratamento de erros
+
+O VSRepository lança `VSRepoError` e suas subclasses em situações específicas (erros do Prisma não são sobrescritos):
+
+```ts
+import { VSRepoError, VSRepoRuntimeError } from "../../generated/vsrepo";
+
+try {
+  const user = await userRepository.getOrThrow("id-that-does-not-exist");
+} catch (error) {
+  if (error instanceof VSRepoRuntimeError && error.code === "20727") {
+    console.error("Record not found");
+  } else if (error instanceof VSRepoError) {
+    console.error("Repository error:", error.message);
+  } else {
+    console.error("Error:", error.message)
+  }
+}
+```
+
+**Subclasses disponíveis:**
+
+| Classe                    | Quando é lançada                                                     |
+| ------------------------- | -------------------------------------------------------------------- |
+| `VSRepoConfigError`       | Configuração inválida em `setupVSRepo`                               |
+| `VSRepoBuildError`        | Nome de método, tipo de campo ou configuração inválida em `build`    |
+| `VSRepoExtendError`       | Argumento inválido em `extend`                                       |
+| `VSRepoDecoratorError`    | Argumento inválido passado para `@DynamicMethod` ou `@QueryMethod`   |
+| `VSRepoRuntimeError`      | Erro em tempo de execução durante uma operação                       |
+
+`VSRepoRuntimeError` tem uma propriedade `code: VSRepoRuntimeErrorCode` para identificação programática, sem precisar fazer parsing da mensagem (legível por humanos, e possivelmente localizada):
+
+| Código | Significado |
+| ------ | ----------- |
+| `"65706"` | Um argumento obrigatório está ausente ou tem formato inválido — ex.: `pk` ausente, `pks`/`objs`/`tuples` que não são um array, ou `options`/`obj` que não são um objeto válido. |
+| `"20727"` | Nenhum registro foi encontrado para a primary key informada (`getOrThrow` ao buscar o registro base). |
+| `"67542"` | A validação (zod) de `options` de um método, ou de um argumento de `@QueryMethod`, falhou. |
+| `"91868"` | Uma relação passada em `save`/`patch`/`merge` tem formato inválido para o `mode`/`restriction` configurados (ex.: `null` numa relação `mtm`/`otm`, ou um array numa relação `oto`/`mto`). |
+| `"48670"` | Um método dinâmico (`config.methods`) foi chamado com menos argumentos posicionais do que os campos do `where` exigem. |
+
+---
+
+## Tipos utilitários
+
+### Tipos de client
+
+```ts
+import type { DbClient, DbTransaction, ClientOrTransaction } from "../../generated/vsrepo";
+
+type DbClient            = PrismaClient;
+type DbTransaction       = Prisma.TransactionClient;
+type ClientOrTransaction = DbClient | DbTransaction;
+```
+
+### Tipo de visibilidade do soft-delete
+
+```ts
+import type { SeeMode } from "../../generated/vsrepo";
+
+type SeeMode = "active" | "removed" | "all";
+```
+
+### Tipos derivados do modelo Prisma
+
+```ts
+import type {
+  SelectModel,
+  SelectModels,
+  IncludeModel,
+  IncludeModels,
+  WhereModel,
+  OrderingModel,
+  PaginationModel,
+  ModelUpsertInput,
+  PrismaModelInputs,
+} from "../../generated/vsrepo";
+```
+
+### Tipos de opções de método
+
+```ts
+import type { MethodOptions, MethodOptionsModel } from "../../generated/vsrepo";
+
+// MethodOptions<S, IM> — opções passadas para os métodos do repositório
+type Opts = MethodOptions<"public" | "minimal", "withPosts">;
+
+// MethodOptionsModel<TRepo> — derivado de uma instância configurada do VSRepository
+const userVSRepo = setupVSRepo<User, "user">()(config);
+type OptsModel = MethodOptionsModel<typeof userVSRepo>;
+```
+
+> O segundo parâmetro de `MethodOptions` (`IM`) representa as chaves válidas de `includeModels`. Quando informado, `selectModel` e `includeModel` se tornam mutuamente exclusivos no tipo — não é possível passar os dois na mesma chamada.
+>
+> `MethodOptions` também aceita mais dois parâmetros genéricos, `RI` e `RS`, para tipar `include` e `select` brutos respectivamente (ambos com padrão `never`, ou seja, não são aceitos a menos que tipados explicitamente): `MethodOptions<"public", "withPosts", "usuario", IncludeModel<"usuario">, SelectModel<"usuario">>`. O `MethodOptionsModel`, derivado diretamente de um repositório configurado, não expõe `RI`/`RS` — use `MethodOptions` diretamente se precisar tipar as opções de `include`/`select` brutos.
+
+### Tipos de configuração
+
+```ts
+import type {
+  MethodConfig,
+  RepoConfig,
+  BuildConfig,
+  RepositoryRelations,
+  ExtractRelationConfig,
+} from "../../generated/vsrepo";
+```
+
+### Tipo do repositório construído
+
+```ts
+import type { RepositoryOf } from "../../generated/vsrepo";
+
+const userVSRepo = setupVSRepo<User, "user">()({ ... });
+type UserRepository = RepositoryOf<typeof userVSRepo>;
+```
+
+`RepositoryOf` aceita três parâmetros:
+
+```ts
+type RepositoryOf<TRepo, C extends BuildConfig | undefined = undefined, E = unknown>
+```
+
+### Tipos de payload para `save` e `patch`
+
+```ts
+import type { SaveObject, PatchObject } from "../../generated/vsrepo";
+
+const userVSRepo = setupVSRepo<User, "user">()(({
+  tableName: "user",
+  pkName: "id",
+  relations: {
+    profile: { pk: "id", mode: "oto", restriction: "set" },
+  },
+});
+
+type UserSavePayload  = SaveObject<Prisma.UserCreateInput, typeof userVSRepo>;
+type UserPatchPayload = PatchObject<Prisma.UserUpdateInput, typeof userVSRepo>;
+```
+
+---
+
+## Referência da API
+
+### `setupVSRepo<T, M>()(config)`
+
+```ts
+setupVSRepo<TPayload, TTableName>()({
+  tableName: Uncapitalize<M>;                     // Nome da tabela no Prisma
+  pkName: keyof T;                                // Nome da chave primária
+  softRemovekName?: keyof T & string;             // Campo DateTime para soft-delete
+  selectModels?: SelectModels<M>;                 // Projeções de dados nomeadas (select)
+  defaultSelectModel?: keyof SM;                  // Select aplicado por padrão
+  includeModels?: IncludeModels<M>;               // Projeções de dados nomeadas (include) — sem padrão, apenas na chamada
+  requiredWhere?: WhereModel<M>;                  // Filtros sempre aplicados
+  defaultOrdering?: OrderingModel<M>;             // Ordenação padrão para queries sem Ordered/injectOrdering
+  relations?: RepositoryRelations<T>;             // Configuração de relações
+  methods?: Record<string, MethodConfig<M, SM>>;  // Métodos dinâmicos
+});
+```
+
+### `.build(prisma, config?)`
+
+```ts
+vsRepo.build(prisma, {
+  showWorking?: boolean;   // Exibe os logs internos no console (padrão = false)
+
+  baseMethods?: {
+    // Métodos que podem usar um defaultSelect
+    get?:             { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    getOrThrow?:      { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    getList?:         { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    remove?:          { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    save?:            { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    saveList?:        { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    patch?:           { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    patchList?:       { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    merge?:           { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    getAll?:          { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    softRemove?:      { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+    restore?:         { active?: boolean; defaultSelect?: string; ignoreRequiredWhere?: boolean };
+
+    // Métodos que NÃO aceitam defaultSelect
+    removeList?:      { active?: boolean; ignoreRequiredWhere?: boolean };
+    softRemoveList?:  { active?: boolean; ignoreRequiredWhere?: boolean };
+    restoreList?:     { active?: boolean; ignoreRequiredWhere?: boolean };
+    total?:           { active?: boolean; ignoreRequiredWhere?: boolean };
+    has?:             { active?: boolean; ignoreRequiredWhere?: boolean };
+  };
+});
+```
+
+### `.extend(fn)`
+
+```ts
+repo.extend((repo) => ({
+  myMethod: () => { ... }
+}));
+```
+
+---
+
+## Exemplos práticos
+
+Além deste README, o repositório tem uma pasta **[`examples/`](https://github.com/jaobrabo123/VSRepository/tree/main/examples)** com exemplos práticos, comentados e prontos para executar — é o melhor lugar para ver o VSRepository sendo usado em cenários reais.
+
+```text
+examples/
+├── prisma.ts             # Instância do PrismaClient usada pelos exemplos
+├── repositories.ts       # Configuração dos repositórios (User, Address, Product) com setupVSRepo
+└── tests/
+    ├── base-methods.test.ts       # Métodos base: get, save, patch, remove, getAll, total, has...
+    ├── relations.test.ts          # Como configurar e usar relações em save/patch e em filtros
+    ├── required-where.test.ts     # Como requiredWhere é aplicado automaticamente às queries
+    ├── dynamic-methods.test.ts    # Prefixos, filtros de campo, operadores lógicos e paginação/ordenação
+    ├── transactions.test.ts       # Transações com options.db e acesso à instância via repository.prisma
+    ├── soft-delete.test.ts        # Soft-delete: softRemove, softRemoveList, restore, restoreList e SeeMode
+    └── batch-methods.test.ts      # Operações em lote: getList, saveList, patchList e merge
+```
+
+Cada arquivo em `tests/` é um script independente e executável (via `tsx`) que demonstra um conjunto específico de funcionalidades, com `console.log` em cada etapa para você acompanhar o resultado no terminal. A própria pasta tem um [README](https://github.com/jaobrabo123/VSRepository/blob/main/examples/README.md) explicando a ordem de leitura sugerida, como configurar o ambiente e como rodar os testes.
+
+---
+
+## Contribuindo
+
+Contribuições são bem-vindas! Se você encontrou um bug, tem uma ideia de melhoria ou quer ajudar com a documentação, sinta-se à vontade para participar (**[Repositório no GitHub](https://github.com/jaobrabo123/VSRepository)**):
+
+1. Faça um **fork** do projeto.
+2. Crie uma nova branch com sua alteração: `git checkout -b fixing-bug`.
+3. Envie para sua branch: `git push origin fixing-bug`.
+4. Abra um **Pull Request**.
+
+Para reportar problemas ou sugerir novas funcionalidades, abra uma **Issue**.
+
+---
+
+## Requisitos
+
+- Node.js 18+ (ESM)
+- Prisma
+- TypeScript (opcional, mas fortemente recomendado)
+- `"moduleResolution": "bundler"` ou `"nodenext"` no tsconfig
+
+`tsconfig.json` recomendado:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020"]
+  }
+}
+```
+
+---
+
+## Solução de problemas
+
+**Tipos genéricos não são inferidos** — Verifique se `strict: true` e `moduleResolution: "bundler"` ou `"nodenext"` estão configurados no `tsconfig.json`.
+
+**Método dinâmico não existe em tempo de execução** — O campo referenciado no nome do método deve existir no modelo do Prisma. Ex.: `findByEmail` requer que o modelo tenha um campo `email`.
+
+**`proxyTo` obrigatório** — Nomes fora dos padrões conhecidos (ex.: `searchByEmail`) não são interpretados diretamente. Use `proxyTo: "findByEmail"` nesses casos.
+
+**Select model retorna campos inesperados** — Verifique se o select model define exatamente os campos que o seu tipo TypeScript espera.
+
+**`selectModel`, `includeModel` e `include` juntos na mesma chamada** — Não é permitido. Apenas um dos três pode ser informado por chamada: se `includeModel` ou `include` for informado, o `select` (incluindo `defaultSelectModel`) é ignorado e apenas o `include` é enviado ao Prisma.
+
+**`includeModel` não aparece como opção padrão do repositório** — Isso é esperado. Diferente do `defaultSelectModel`, não existe `defaultIncludeModel`/`defaultInclude`. Um `includeModel` só pode ser definido na chamada do método, via `options.includeModel`. Um include bruto e ad hoc pode ser definido via `options.include`, sem precisar ser registrado em `includeModels`.
+
+**`softRemovekName` lança um erro no build** — O campo informado deve ser do tipo `DateTime` no schema do Prisma. Tipos como `Boolean` ou `String` não são aceitos.
+
+**`defaultOrdering` não está sendo aplicado** — Verifique se o método usa o sufixo `Ordered`, `OrderedAndPaginated` ou `PaginatedAndOrdered`, e se tem `injectOrdering` configurado. Ambos têm prioridade sobre a ordenação padrão.
+
+**Sufixo `Distinct` não é reconhecido** — `Distinct` só é resolvido em prefixos de leitura (`findMany`, `findFirst`, `findBy`, `existsBy`, etc). Em métodos como `count`, `createMany`, `updateMany` ou `deleteMany` o sufixo é ignorado.
+
+**`saveList`/`patchList` com `db` inválido** — O campo `db` nesses métodos só aceita uma `DbTransaction` (o retorno de `prisma.$transaction`), não o client principal. Passar o `PrismaClient` diretamente causará comportamento inesperado.

--- a/scripts/configure-prisma-import.mjs
+++ b/scripts/configure-prisma-import.mjs
@@ -236,16 +236,28 @@ for (const file of tsFiles) {
   console.log(`Gerado: ${path.relative(workspaceRoot, targetFile)}`);
 }
 
-// Copia o README.md do pacote VSRepository para o diretório de output, se existir
-// const readmeSource = path.join(packageRoot, 'README.md');
-// const readmeTarget = path.join(outputDir, 'README.md');
+// Copia os READMEs da raiz do projeto para a pasta 'docs' do diretório de output
+const readmeFiles = [
+  'README.md',
+  'README.pt-BR.md',
+  'README-DynamicRepo.md',
+  'README-DynamicRepo.pt-BR.md',
+];
 
-// if (fs.existsSync(readmeSource)) {
-//   fs.copyFileSync(readmeSource, readmeTarget);
-//   console.log(`Gerado: ${path.relative(workspaceRoot, readmeTarget)}`);
-// } else {
-//   console.warn(`README.md do VSRepository nao encontrado em: ${path.relative(workspaceRoot, readmeSource)}. Ignorando a copia.`);
-// }
+const readmeOutputDir = path.join(outputDir, 'docs');
+fs.mkdirSync(readmeOutputDir, { recursive: true });
+
+for (const fileName of readmeFiles) {
+  const readmeSource = path.join(workspaceRoot, fileName);
+  const readmeTarget = path.join(readmeOutputDir, fileName);
+
+  if (fs.existsSync(readmeSource)) {
+    fs.copyFileSync(readmeSource, readmeTarget);
+    console.log(`Gerado: ${path.relative(workspaceRoot, readmeTarget)}`);
+  } else {
+    console.warn(`README nao encontrado em: ${path.relative(workspaceRoot, readmeSource)}. Ignorando a copia.`);
+  }
+}
 
 console.log('\nVSRepository gerado com tipagem do Prisma.');
 console.log(`Output: ${path.relative(workspaceRoot, outputDir)}`);


### PR DESCRIPTION
This pull request updates the logic for copying README files in the `scripts/configure-prisma-import.mjs` script. Instead of copying a single README from the package, it now copies multiple README files from the project root into a `docs` folder within the output directory.

**Documentation handling improvements:**

* The script now copies multiple README files (`README.md`, `README.pt-BR.md`, `README-DynamicRepo.md`, and `README-DynamicRepo.pt-BR.md`) from the project root into a new `docs` subdirectory inside the output directory. This ensures all relevant documentation variants are included in the build output.
* The script creates the `docs` folder if it doesn't exist and logs a warning for any missing README files, improving robustness and developer feedback.