### PR TITLE
fix: corrige a copia dos arquivos MD

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,11 @@
   "type": "commonjs",
   "files": [
     "dist",
-    "scripts"
+    "scripts",
+    "README.md",
+    "README.pt-BR.md",
+    "README-DynamicRepo.md",
+    "README-DynamicRepo.pt-BR.md"
   ],
   "bin": {
     "vsrepo": "scripts/configure-prisma-import.mjs"

--- a/scripts/configure-prisma-import.mjs
+++ b/scripts/configure-prisma-import.mjs
@@ -236,7 +236,8 @@ for (const file of tsFiles) {
   console.log(`Gerado: ${path.relative(workspaceRoot, targetFile)}`);
 }
 
-// Copia os READMEs da raiz do projeto para a pasta 'docs' do diretório de output
+// Copia os READMEs da raiz do PACOTE vsrepo (nao do projeto do consumidor)
+// para a pasta 'docs' do diretório de output.
 const readmeFiles = [
   'README.md',
   'README.pt-BR.md',
@@ -248,14 +249,14 @@ const readmeOutputDir = path.join(outputDir, 'docs');
 fs.mkdirSync(readmeOutputDir, { recursive: true });
 
 for (const fileName of readmeFiles) {
-  const readmeSource = path.join(workspaceRoot, fileName);
+  const readmeSource = path.join(packageRoot, fileName);
   const readmeTarget = path.join(readmeOutputDir, fileName);
 
   if (fs.existsSync(readmeSource)) {
     fs.copyFileSync(readmeSource, readmeTarget);
     console.log(`Gerado: ${path.relative(workspaceRoot, readmeTarget)}`);
   } else {
-    console.warn(`README nao encontrado em: ${path.relative(workspaceRoot, readmeSource)}. Ignorando a copia.`);
+    console.warn(`README nao encontrado no pacote em: ${readmeSource}. Ignorando a copia.`);
   }
 }
 


### PR DESCRIPTION
This pull request updates how README files are included and copied in the package. The main focus is to ensure that multiple README files from the package root are properly distributed and copied to the output directory, improving documentation handling for consumers.

**Documentation distribution and copying:**

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L37-R41): Added several README files (`README.md`, `README.pt-BR.md`, `README-DynamicRepo.md`, `README-DynamicRepo.pt-BR.md`) to the `files` array to ensure they are included when the package is published.
* [`scripts/configure-prisma-import.mjs`](diffhunk://#diff-0f1742f4a5cb4f021820b7aa47540c90cd1951026483331b881b4be5ff83b6b4L239-R240): Updated the script to copy README files from the package root (not the consumer project) to the `docs` directory in the output, and improved log messages for missing files. [[1]](diffhunk://#diff-0f1742f4a5cb4f021820b7aa47540c90cd1951026483331b881b4be5ff83b6b4L239-R240) [[2]](diffhunk://#diff-0f1742f4a5cb4f021820b7aa47540c90cd1951026483331b881b4be5ff83b6b4L251-R259)