### PR TITLE
fix: corrige merge de filtros de relation; test: adiciona teste de re…

### DIFF
--- a/src/internal/resolvers/specific-where.resolve.ts
+++ b/src/internal/resolvers/specific-where.resolve.ts
@@ -1,7 +1,8 @@
+import merge from "deepmerge";
 import { PrettyWhere } from "./types/pretty-where.type";
 
 export function resolveSpecificWhere(args: any[], prettyWheres: PrettyWhere[]) {
-    const specificWhere: Record<string, any> = {};
+    let specificWhere: Record<string, any> = {};
     let OR: any[] | undefined;
     let AND: any[] | undefined;
 
@@ -45,16 +46,20 @@ export function resolveSpecificWhere(args: any[], prettyWheres: PrettyWhere[]) {
         if (currentWhereRslvd.otherProps !== undefined) {
             Object.assign(path[currentWhereRslvd.argName], currentWhereRslvd.otherProps);
         }
+
         if (ormode) {
             if (!OR) OR = [];
             if (!OR[modeIdx!]) OR[modeIdx!] = {};
-            Object.assign(OR[modeIdx!], path);
+            OR[modeIdx!] = merge(OR[modeIdx!], path)
+            // Object.assign(OR[modeIdx!], path);
         } else if (andmode) {
             if (!AND) AND = [];
             if (!AND[modeIdx!]) AND[modeIdx!] = {};
-            Object.assign(AND[modeIdx!], path);
+            AND[modeIdx!] = merge(AND[modeIdx!], path);
+            // Object.assign(AND[modeIdx!], path);
         } else {
-            Object.assign(specificWhere, path);
+            specificWhere = merge(specificWhere, path)
+            // Object.assign(specificWhere, path);
         }
     }
 

--- a/src/internal/resolvers/ugly-where.resolve.ts
+++ b/src/internal/resolvers/ugly-where.resolve.ts
@@ -98,6 +98,7 @@ export function resolveUglyWhere(keySplitedAnd: string) {
         } else {
             uglyWhere.pushProperty = `isNot.${uncapitalize(specificField)}${uglyWhere.pushProperty === "$$$" ? "" : `.${uglyWhere.pushProperty}`}`;
         }
+
         keySplitedAnd = keySplitedConector[0]!;
     } else if (keySplitedAnd.includes("With")) {
         const keySplitedConector = keySplitedAnd.split("With");
@@ -112,6 +113,7 @@ export function resolveUglyWhere(keySplitedAnd: string) {
         } else {
             uglyWhere.pushProperty = `is.${uncapitalize(specificField)}${uglyWhere.pushProperty === "$$$" ? "" : `.${uglyWhere.pushProperty}`}`;
         }
+
         keySplitedAnd = keySplitedConector[0]!;
     } else if (keySplitedAnd.includes("Some")) {
         const keySplitedConector = keySplitedAnd.split("Some");
@@ -122,6 +124,7 @@ export function resolveUglyWhere(keySplitedAnd: string) {
         } else {
             uglyWhere.pushProperty = `some.${uncapitalize(specificField)}${uglyWhere.pushProperty === "$$$" ? "" : `.${uglyWhere.pushProperty}`}`;
         }
+
         keySplitedAnd = keySplitedConector[0]!;
     } else if (keySplitedAnd.includes("Every")) {
         const keySplitedConector = keySplitedAnd.split("Every");
@@ -132,6 +135,7 @@ export function resolveUglyWhere(keySplitedAnd: string) {
         } else {
             uglyWhere.pushProperty = `every.${uncapitalize(specificField)}${uglyWhere.pushProperty === "$$$" ? "" : `.${uglyWhere.pushProperty}`}`;
         }
+
         keySplitedAnd = keySplitedConector[0]!;
     } else if (keySplitedAnd.includes("None")) {
         const keySplitedConector = keySplitedAnd.split("None");
@@ -142,6 +146,7 @@ export function resolveUglyWhere(keySplitedAnd: string) {
         } else {
             uglyWhere.pushProperty = `none.${uncapitalize(specificField)}${uglyWhere.pushProperty === "$$$" ? "" : `.${uglyWhere.pushProperty}`}`;
         }
+
         keySplitedAnd = keySplitedConector[0]!;
     }
 

--- a/test/implementation/specific-where.test.ts
+++ b/test/implementation/specific-where.test.ts
@@ -1,0 +1,183 @@
+// Teste de regressão para resolveSpecificWhere.
+//
+// Contexto do bug: quando um mesmo método dinâmico combina mais de um filtro que
+// aponta para a MESMA relation (ex.: EnderecoWithEstado e EnderecoWithCidadeNormalizada
+// na mesma query), o merge anterior usava Object.assign (merge raso), então o segundo
+// filtro da relation SUBSTITUÍA o objeto inteiro da relation, fazendo o primeiro filtro
+// desaparecer da query gerada.
+//
+// Correção: trocar Object.assign por deepmerge (merge profundo), preservando todos os
+// filtros da relation. Estes testes garantem que esse comportamento não volte a quebrar.
+
+import { describe, it, expect } from "@jest/globals";
+import { resolveSpecificWhere } from "../../src/internal/resolvers/specific-where.resolve";
+import { PrettyWhere } from "../../src/internal/resolvers/types/pretty-where.type";
+
+// * Helper p/ montar um PrettyWhere com mais legibilidade nos testes
+function W(context: (string | number)[], opts: Partial<PrettyWhere> = {}): PrettyWhere {
+    const lastKey = context[context.length - 1];
+    return {
+        context,
+        argName: lastKey === undefined ? "" : String(lastKey),
+        ...opts,
+    };
+}
+
+// =============================================================================
+// REGRESSÃO DO BUG ORIGINAL: múltiplos filtros na MESMA relation
+// =============================================================================
+
+describe("resolveSpecificWhere — múltiplos filtros na mesma relation", () => {
+    it("mantém os dois filtros da relation 'endereco.is' (estado + cidadeNormalizada)", () => {
+        // Corresponde a: findByTercerizadoAndDisponivelOffshoreAndIdiomasSomeIdiomaAndEnderecoWithEstadoAndEnderecoWithCidadeNormalizadaStartsWithPaginated
+        const prettyWheres = [
+            W(["tercerizado"]),
+            W(["disponivelOffshore"]),
+            W(["idiomas", "some", "idioma"]),
+            W(["endereco", "is", "estado"]),
+            W(["endereco", "is", "cidadeNormalizada", "startsWith"]),
+        ];
+
+        const result = resolveSpecificWhere(Array(prettyWheres.length).fill("00"), prettyWheres);
+
+        expect(result).toEqual({
+            tercerizado: "00",
+            disponivelOffshore: "00",
+            idiomas: { some: { idioma: "00" } },
+            endereco: {
+                is: {
+                    estado: "00",
+                    cidadeNormalizada: { startsWith: "00" },
+                },
+            },
+        });
+    });
+
+    it("preserva operadores diferentes no mesmo campo da relation (startsWith + equals)", () => {
+        const prettyWheres = [
+            W(["endereco", "is", "cidadeNormalizada", "startsWith"]),
+            W(["endereco", "is", "cidadeNormalizada", "equals"]),
+        ];
+
+        const result = resolveSpecificWhere(["Avenida", "Avenida Paulista"], prettyWheres);
+
+        expect(result).toEqual({
+            endereco: {
+                is: {
+                    cidadeNormalizada: { startsWith: "Avenida", equals: "Avenida Paulista" },
+                },
+            },
+        });
+    });
+
+    it("combina 'With' puro (autoVal {}) com 'WithCampo' em qualquer ordem", () => {
+        // Ordem 1: With puro depois de WithCampo
+        const order1 = resolveSpecificWhere(Array(2).fill("00"), [
+            W(["endereco", "is", "estado"]),
+            W(["endereco", "is"], { autoVal: {} }),
+        ]);
+        expect(order1).toEqual({ endereco: { is: { estado: "00" } } });
+
+        // Ordem 2: With puro antes de WithCampo
+        const order2 = resolveSpecificWhere(Array(2).fill("00"), [
+            W(["endereco", "is"], { autoVal: {} }),
+            W(["endereco", "is", "estado"]),
+        ]);
+        expect(order2).toEqual({ endereco: { is: { estado: "00" } } });
+    });
+
+    it("mescla betweenMode com outro operador no mesmo campo", () => {
+        const prettyWheres = [
+            W(["valor"], { betweenMode: true }),
+            W(["valor", "gt"]),
+        ];
+
+        const result = resolveSpecificWhere([[10, 20], 5], prettyWheres);
+
+        expect(result).toEqual({ valor: { gte: 10, lte: 20, gt: 5 } });
+    });
+});
+
+// =============================================================================
+// OR / AND groups com filtros na mesma relation
+// =============================================================================
+
+describe("resolveSpecificWhere — grupos OR/AND", () => {
+    it("mescla profundamente filtros da mesma relation dentro de um grupo OR", () => {
+        const prettyWheres = [
+            W(["OR", 0, "endereco", "is", "estado"]),
+            W(["OR", 0, "endereco", "is", "cidadeNormalizada", "startsWith"]),
+            W(["OR", 1, "nome", "contains"]),
+            W(["OR", 1, "ativo"]),
+        ];
+
+        const result = resolveSpecificWhere(Array(4).fill("00"), prettyWheres);
+
+        expect(result).toEqual({
+            OR: [
+                {
+                    endereco: {
+                        is: {
+                            estado: "00",
+                            cidadeNormalizada: { startsWith: "00" },
+                        },
+                    },
+                },
+                { nome: { contains: "00" }, ativo: "00" },
+            ],
+        });
+    });
+
+    it("mescla profundamente filtros da mesma relation dentro de um grupo AND", () => {
+        const prettyWheres = [
+            W(["AND", 0, "endereco", "is", "estado"]),
+            W(["AND", 0, "endereco", "is", "cidadeNormalizada", "startsWith"]),
+            W(["AND", 1, "nome"]),
+        ];
+
+        const result = resolveSpecificWhere(Array(3).fill("00"), prettyWheres);
+
+        expect(result).toEqual({
+            AND: [
+                {
+                    endereco: {
+                        is: {
+                            estado: "00",
+                            cidadeNormalizada: { startsWith: "00" },
+                        },
+                    },
+                },
+                { nome: "00" },
+            ],
+        });
+    });
+
+    it("não deixa 'buracos' (undefined) no array de OR", () => {
+        const prettyWheres = [W(["OR", 2, "nome"])];
+
+        const result = resolveSpecificWhere(["x"], prettyWheres);
+
+        expect(result.OR).toEqual([{ nome: "x" }]);
+    });
+});
+
+// =============================================================================
+// Camadas/relações diferentes não interferem entre si
+// =============================================================================
+
+describe("resolveSpecificWhere — isolamento entre relations", () => {
+    it("mantém relations distintas sem mesclar seus campos", () => {
+        const prettyWheres = [
+            W(["endereco", "is", "estado"]),
+            W(["idiomas", "some", "idioma"]),
+            W(["endereco", "is", "cidadeNormalizada", "startsWith"]),
+        ];
+
+        const result = resolveSpecificWhere(Array(3).fill("00"), prettyWheres);
+
+        expect(result).toEqual({
+            endereco: { is: { estado: "00", cidadeNormalizada: { startsWith: "00" } } },
+            idiomas: { some: { idioma: "00" } },
+        });
+    });
+});


### PR DESCRIPTION
This pull request improves the merging logic for building query filters in the `resolveSpecificWhere` function to fix a bug where multiple filters on the same relation would overwrite each other. It replaces shallow merges using `Object.assign` with deep merges using the `deepmerge` library, ensuring all filters are preserved. Additionally, it adds comprehensive regression tests to prevent this issue from reoccurring and includes minor formatting changes in related code.

**Bug fix and improvements:**

* Replaced all uses of `Object.assign` with `deepmerge` in `resolveSpecificWhere` to perform deep merges of filter objects, preventing filters on the same relation from overwriting each other. [[1]](diffhunk://#diff-920344419e38d5f2c69db8a9c51341b9d5a1b02776e49483bd54b257880f97c4R1-R5) [[2]](diffhunk://#diff-920344419e38d5f2c69db8a9c51341b9d5a1b02776e49483bd54b257880f97c4R49-R62)

**Testing and regression coverage:**

* Added a new test suite in `specific-where.test.ts` with regression tests that cover scenarios where multiple filters target the same relation, ensuring that all filters are correctly merged and preserved.

**Code formatting:**

* Added minor formatting improvements (extra line breaks) for readability in `resolveUglyWhere`. [[1]](diffhunk://#diff-999a592d2aaca04e519e374b3be5955d6252a9bf9056ed65ef4061f6b191643aR101) [[2]](diffhunk://#diff-999a592d2aaca04e519e374b3be5955d6252a9bf9056ed65ef4061f6b191643aR116) [[3]](diffhunk://#diff-999a592d2aaca04e519e374b3be5955d6252a9bf9056ed65ef4061f6b191643aR127) [[4]](diffhunk://#diff-999a592d2aaca04e519e374b3be5955d6252a9bf9056ed65ef4061f6b191643aR138) [[5]](diffhunk://#diff-999a592d2aaca04e519e374b3be5955d6252a9bf9056ed65ef4061f6b191643aR149)