### PR TITLE
Atomic ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ All notable changes to this project will be documented in this file.
 
 ---
  
+## [2.1.0] - 2026-09-04
+
+### Added
+- **Atomic operations** — new `increment(pk, field, value)`, `decrement`, `multiply` and `divide` methods on `VSRepository`. They are evaluated **server-side** against the row's *current* value (`UPDATE ... SET field = field + value`), not as a client-side read-modify-write, and each returns the record reflecting the state *after* the write. The `value` argument accepts `number`, `bigint` or `DecimalLike` and is validated at runtime
+- **Aggregation methods** — new `sum`, `average`, `min` and `max` methods that compute the value across every record matching an optional `where` (all records if omitted). All four return `number | null` — `null` when no record matches, mirroring SQL's `SUM()`/`AVG()`/`MIN()`/`MAX()`, which return `NULL` (not `0`) over an empty set
+- **`VSRepoAdapter` contract extended** with the 8 corresponding abstract methods: `incrementOne`, `decrementOne`, `multiplyOne`, `divideOne`, `sum`, `average`, `min`, `max`
+- New public types: `NumericKeys<T>` (extracts the numeric fields eligible as `field`), `NumericLike` (`number | bigint | DecimalLike`), `DecimalLike` (structural shape of arbitrary-precision decimals such as Prisma's `Prisma.Decimal`), and `RestrictMethodOptions`
+- `Primitive` now also includes `DecimalLike`, so Decimal-typed fields are treated as scalar (non-relation) values when walking an entity's shape
+- Implementation and typing tests covering the atomic and aggregate methods, plus README docs and JSDoc for every new method and type
+
+> **Note for adapter authors:** the new abstract methods are **breaking** for anyone implementing a custom `VSRepoAdapter` — existing adapters must implement all 8 before they compile against 2.1.0. Published adapters (e.g. `@vsrepo/prisma7-adapter`) may not implement them yet; confirm the adapter version supports them before relying on `increment`/`sum`/etc.
+
+### Changed
+- `total`, `has`, `removeList`, `softRemoveList` and `restoreList` now accept the narrowed `RestrictMethodOptions` (`db`/`see` only) instead of the full `MethodOptions` — these methods don't shape/return an `Entity`, so `select`/`relations` no longer apply at the type level
+- The `v1` folder was removed from the `main` branch — the v1 source and docs now live exclusively on the dedicated `v1` branch (READMEs updated to point there)
+
+---
+
+## [2.1.0] - 2026-09-04 (Português)
+
+### Adicionado
+- **Operações atômicas** — novos métodos `increment(pk, field, value)`, `decrement`, `multiply` e `divide` no `VSRepository`. Elas são avaliadas **server-side** contra o valor *atual* do registro (`UPDATE ... SET field = field + value`), e não como um read-modify-write no cliente, e cada uma retorna o registro refletindo o estado *após* a escrita. O argumento `value` aceita `number`, `bigint` ou `DecimalLike` e é validado em tempo de execução
+- **Métodos de agregação** — novos métodos `sum`, `average`, `min` e `max` que calculam o valor entre todos os registros que correspondem a um `where` opcional (todos os registros se omitido). Os quatro retornam `number | null` — `null` quando nenhum registro corresponde, espelhando o `SUM()`/`AVG()`/`MIN()`/`MAX()` do SQL, que retornam `NULL` (não `0`) sobre um conjunto vazio
+- **Contrato do `VSRepoAdapter` estendido** com os 8 métodos abstratos correspondentes: `incrementOne`, `decrementOne`, `multiplyOne`, `divideOne`, `sum`, `average`, `min`, `max`
+- Novos tipos públicos: `NumericKeys<T>` (extrai os campos numéricos elegíveis como `field`), `NumericLike` (`number | bigint | DecimalLike`), `DecimalLike` (formato estrutural de decimais de alta precisão, como o `Prisma.Decimal` do Prisma) e `RestrictMethodOptions`
+- `Primitive` agora também inclui `DecimalLike`, então campos com tipo Decimal são tratados como valores escalares (não-relation) ao percorrer a forma da entidade
+- Testes de implementação e de tipagem cobrindo os métodos atômicos e de agregação, além de documentação nos READMEs e JSDoc para cada novo método e tipo
+
+> **Nota para autores de adapters:** os novos métodos abstratos são uma mudança **breaking** para quem implementa um `VSRepoAdapter` customizado — adapters existentes precisam implementar os 8 antes de compilarem contra a 2.1.0. Adapters publicados (ex.: `@vsrepo/prisma7-adapter`) podem ainda não os implementar; confirme que a versão do adapter suporta antes de usar `increment`/`sum`/etc.
+
+### Alterado
+- `total`, `has`, `removeList`, `softRemoveList` e `restoreList` agora aceitam o `RestrictMethodOptions` restrito (somente `db`/`see`) em vez do `MethodOptions` completo — esses métodos não moldam/retornam uma `Entity`, então `select`/`relations` não se aplicam mais no nível de tipos
+- A pasta `v1` foi removida da branch `main` — o código-fonte e a documentação da v1 agora vivem exclusivamente na branch `v1` dedicada (READMEs atualizados para apontar para lá)
+
+---
+
 ## [2.0.0] - 2026-09-01
  
 > Major rewrite. If you're upgrading from v1, see the ["What changed from v1"](./README.md#what-changed-from-v1) table in the README for the full breakdown before migrating.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ VSRepository lets you create strongly-typed repositories with:
 - [Constructor options](#constructor-options)
 - [Base methods](#base-methods)
 - [Soft-delete](#soft-delete)
+- [Atomic and aggregate methods](#atomic-and-aggregate-methods)
+    - [Which fields are eligible](#which-fields-are-eligible)
+    - [Writing an adapter](#writing-an-adapter)
 - [`select` and `relations`](#select-and-relations)
 - [Dynamic methods](#dynamic-methods)
     - [Available prefixes](#available-prefixes)
@@ -97,7 +100,7 @@ The Prisma 7 adapter has now been published to npm as `@vsrepo/prisma7-adapter` 
 
 | Adapter                                                                                  | Status                                                                                                                                                                                                       |
 | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Prisma 7 (`@vsrepo/prisma7-adapter`)                                                     | 🟢 **Released** — published to npm, implements the entire `VSRepoAdapter` contract (CRUD, relations, transactions, `merge`, logging) with tests; see [`VSRepoPrisma7Adapter`](https://github.com/jaobrabo123/VSRepoPrisma7Adapter) for source and docs. |
+| Prisma 7 (`@vsrepo/prisma7-adapter`)                                                     | 🟢 **Released** — published to npm, implements the `VSRepoAdapter` contract (CRUD, relations, transactions, `merge`, logging) with tests; see [`VSRepoPrisma7Adapter`](https://github.com/jaobrabo123/VSRepoPrisma7Adapter) for source and docs. **Note:** the atomic/aggregate methods (`incrementOne`, `decrementOne`, `multiplyOne`, `divideOne`, `sum`, `average`, `min`, `max` — see [Atomic and aggregate methods](#atomic-and-aggregate-methods)) were added to the `VSRepoAdapter` contract after this adapter's last release; confirm its changelog/version implements them before relying on `increment`/`sum`/etc. against Prisma 7. |
 | TypeORM (`@vsrepo/typeorm-adapter`)                                                      | 🟡 **Planned, not published yet.** Only a reference `where`-clause parser (`parseVSRepoWhere`) was written to validate the design; it's the planned starting point for the future `@vsrepo/typeorm-adapter` package. Community contributions toward this are welcome. |
 | Other ORMs (Prisma 8, Drizzle, etc.)                                                     | 🟡 **Planned, not published yet.** No official package exists yet — write your own adapter for now (see [Writing your own adapter](#writing-your-own-adapter)), and consider publishing/contributing it back. |
 | Custom adapters                                                                          | 🟢 Fully supported today — implement the [`VSRepoAdapter`](#writing-your-own-adapter) abstract class yourself for any ORM/database you need, in your own project or package, following the same shape as `@vsrepo/*-adapter` is expected to have. |
@@ -231,11 +234,19 @@ Available automatically on every `VSRepository` subclass:
 | `removeList(pks, options?)` | Deletes multiple records by primary key, returning `{ count }`.                                                                      |
 | `total(options?)`           | Returns the total number of records.                                                                                                 |
 | `has(pk, options?)`         | Checks whether a record exists, returning `boolean`.                                                                                 |
+| `increment(pk, field, value, options?)` | Atomically adds `value` to a numeric field. See [Atomic and aggregate methods](#atomic-and-aggregate-methods).           |
+| `decrement(pk, field, value, options?)` | Atomically subtracts `value` from a numeric field.                                                                        |
+| `multiply(pk, field, value, options?)`  | Atomically multiplies a numeric field by `value`.                                                                         |
+| `divide(pk, field, value, options?)`    | Atomically divides a numeric field by `value`.                                                                            |
+| `sum(field, where?, options?)`          | Sums a numeric field across every matching record; `null` if none match.                                                  |
+| `average(field, where?, options?)`      | Arithmetic mean of a numeric field across every matching record; `null` if none match.                                    |
+| `min(field, where?, options?)`          | Minimum value of a numeric field across every matching record; `null` if none match.                                      |
+| `max(field, where?, options?)`          | Maximum value of a numeric field across every matching record; `null` if none match.                                      |
 | `transaction(fn, options?)` | Runs `fn` inside a native transaction of the underlying ORM.                                                                         |
 | `getDbClient()`             | Returns the underlying ORM client instance used outside of transactions.                                                             |
 | `query<T>(query, options?)` | Executes a raw SQL statement directly against the database. See [Ad-hoc raw queries with `query()`](#ad-hoc-raw-queries-with-query). |
 
-All of the above (except `transaction`, `query`, and `getDbClient`, which accept their own options or none at all) accept a `MethodOptions<Entity, OrmTypes>` object as their last argument (`select`, `relations`, `see`, `db`).
+Most of the above accept a `MethodOptions<Entity, OrmTypes>` object as their last argument (`select`, `relations`, `see`, `db`). A few — `total`, `has`, `removeList`, `sum`, `average`, `min`, `max`, and the soft-delete batch methods (`softRemoveList`/`restoreList`) — don't return/shape an `Entity`, so they accept the narrower `RestrictMethodOptions<Entity, OrmTypes>` instead (`see`, `db` only; no `select`/`relations`). `transaction`, `query`, and `getDbClient` accept their own options or none at all.
 
 ---
 
@@ -267,6 +278,62 @@ await userRepository.getAll({ see: "active" }); // default — only non-deleted 
 await userRepository.getAll({ see: "removed" }); // only soft-deleted records
 await userRepository.getAll({ see: "all" }); // everything, ignoring soft-delete
 ```
+
+---
+
+## Atomic and aggregate methods
+
+Every `VSRepository` subclass gets 8 extra methods for working with numeric fields, split into two groups:
+
+**Atomic updates** — evaluated server-side against the row's *current* value (`UPDATE ... SET field = field + value`), not a client-side read-modify-write:
+
+```typescript
+await userRepository.increment("user-1", "balance", 50); // balance = balance + 50
+await userRepository.decrement("user-1", "balance", 50); // balance = balance - 50
+await userRepository.multiply("user-1", "balance", 2); // balance = balance * 2
+await userRepository.divide("user-1", "balance", 4); // balance = balance / 4
+```
+
+All four return the updated `Entity` and accept the full `MethodOptions<Entity, OrmTypes>` (`select`, `relations`, `see`, `db`) as their last argument, same as `get`/`save`/`patch`.
+
+**Aggregates** — computed across every record matching an (optional) `where`:
+
+```typescript
+await userRepository.sum("balance"); // total balance across every active record
+await userRepository.sum("balance", { active: true }); // ...restricted by a where
+await userRepository.average("balance");
+await userRepository.min("balance");
+await userRepository.max("balance");
+```
+
+All four return `number | null` — `null` when no record matches, mirroring SQL's `SUM()`/`AVG()`/`MIN()`/`MAX()`, which return `NULL` (not `0`) over an empty set. Unlike the atomic methods, they accept the narrower `RestrictMethodOptions<Entity, OrmTypes>` (`see`, `db` only — no `select`/`relations`, since the result is a plain number, not a shaped `Entity`).
+
+Both groups respect `softRemoveKey`/`see` the same way every other base method does — `sum("balance")` only totals non-deleted records by default, pass `{ see: "all" }` or `{ see: "removed" }` to change that.
+
+### Which fields are eligible
+
+`field` is constrained to `NumericKeys<Entity>` — keys whose (non-nullable) value type is a `number`, a `bigint`, or a `DecimalLike` object (anything exposing `toNumber()` and `decimalPlaces()`, matching e.g. Prisma's `Prisma.Decimal`):
+
+```typescript
+type Product = { id: string; name: string; price: Decimal; stock: number | null };
+
+await productRepository.increment(id, "price", new Decimal(10.5)); // ok — Decimal-like
+await productRepository.increment(id, "stock", 5); // ok — nullable numeric fields are included
+await productRepository.increment(id, "name", 1); // compile error — "name" isn't numeric
+```
+
+`value` is typed as `NonNullable<Entity[Field]>` — it must match the field's own type exactly. A `Decimal` field expects a `Decimal` instance, not a plain `number`/`string`:
+
+```typescript
+await productRepository.increment(id, "price", new Decimal(10.5)); // ok
+await productRepository.increment(id, "price", 10.5); // compile error — wrap it: new Decimal(10.5)
+```
+
+Note that several ORMs (Drizzle, MikroORM, TypeORM) represent `decimal`/`numeric` columns as plain `string` by default, to avoid floating-point precision loss — a `string` field does **not** satisfy `NumericKeys<Entity>` out of the box. Configure the column in a numeric mode (or a transformer) on those ORMs if you want the field to be usable with these 8 methods.
+
+### Writing an adapter
+
+`VSRepoAdapter` mirrors the same 8 operations (`incrementOne`, `decrementOne`, `multiplyOne`, `divideOne`, `sum`, `average`, `min`, `max` — see [Writing your own adapter](#writing-your-own-adapter)). Each adapter translates them into whatever its ORM/database considers "native": Prisma has a built-in `{ field: { increment: value } }` update shape and an `aggregate()` call; other ORMs typically need a `QueryBuilder`/raw-`sql` expression (e.g. `SET field = field * :value`, `SELECT SUM(field) ...`) instead. The atomic methods must return the record reflecting the state *after* the write — if the ORM's atomic-update API only returns an affected-row count, issue a follow-up read rather than returning a stale in-memory copy.
 
 ---
 
@@ -615,6 +682,7 @@ Beyond the entity-shaping types covered above (`VSRepoSelect`, `VSRepoRelations`
 ```typescript
 import type {
     MethodOptions,
+    RestrictMethodOptions,
     Pagination,
     Ordering,
     OrderByField,
@@ -624,6 +692,9 @@ import type {
     CountResult,
     QueryMethodArg,
     KeysOfType,
+    NumericKeys,
+    NumericLike,
+    DecimalLike,
     Primitive,
     VSRepoWhere,
     VSRepoOrmTypes,
@@ -634,7 +705,8 @@ import type {
 
 | Type                                                | Description                                                                                                                                                                                          | Used by                                                                                                                                                       |
 | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MethodOptions<T, K>`                               | Options accepted as the last argument of every base and dynamic method: `select`, `relations`, `see`, `db`.                                                                                          | [Base methods](#base-methods), [Dynamic methods](#dynamic-methods).                                                                                           |
+| `MethodOptions<T, K>`                               | Options accepted as the last argument of most base and dynamic methods: `select`, `relations`, `see`, `db`.                                                                                          | [Base methods](#base-methods), [Dynamic methods](#dynamic-methods).                                                                                           |
+| `RestrictMethodOptions<T, K>`                        | Narrowed `MethodOptions<T, K>` exposing only `see`/`db` — used by methods that don't shape/return an `Entity` (`total`, `has`, `sum`, `average`, `min`, `max`, `removeList`, `softRemoveList`, `restoreList`).           | [Base methods](#base-methods), [Atomic and aggregate methods](#atomic-and-aggregate-methods).                                                                 |
 | `Pagination`                                        | `{ limit?, offset? }` accepted by `getAll` and by `Paginated` dynamic methods.                                                                                                                       | [Base methods](#base-methods), [Ordering, pagination and distinct](#ordering-pagination-and-distinct).                                                        |
 | `Ordering<T>` / `OrderByField<T>` / `SortDirection` | Ordering shape accepted by `getAll`, `defaultOrdering` and `injectOrdering`, and by `Ordered` dynamic methods. A single object or a chained array; nested objects order to-one relations.            | [Constructor options](#constructor-options), [Decorator options](#decorator-options), [Ordering, pagination and distinct](#ordering-pagination-and-distinct). |
 | `SeeMode`                                           | `"active" \| "removed" \| "all"` — controls visibility of soft-deleted records.                                                                                                                      | [Soft-delete](#soft-delete).                                                                                                                                  |
@@ -642,6 +714,9 @@ import type {
 | `CountResult`                                       | `{ count: number }` — the shape returned by batch operations.                                                                                                                                        | `removeList`, `softRemoveList`, `restoreList`, `createManyIgnoreConflicts`.                                                                                   |
 | `QueryMethodArg<T>`                                 | `{ args?: T, db? }` — positional SQL parameters (`$1`, `$2`, ...) and transaction client for `@QueryMethod`.                                                                                         | [Query methods (raw SQL)](#query-methods-raw-sql).                                                                                                            |
 | `KeysOfType<T, K>`                                  | Extracts the keys of `T` whose value type is assignable to `K`.                                                                                                                                      | Constrains `pkName` in [Constructor options](#constructor-options) to fields of the entity matching the configured primary-key type.                          |
+| `NumericKeys<T>`                                    | Extracts the keys of `T` whose (non-nullable) value type is assignable to `NumericLike`. Nullable numeric fields (`number \| null`) are included.                                                   | Constrains `field` in [Atomic and aggregate methods](#atomic-and-aggregate-methods) (`increment`, `sum`, etc).                                                |
+| `NumericLike`                                       | `number \| bigint \| DecimalLike`.                                                                                                                                                                    | [Atomic and aggregate methods](#atomic-and-aggregate-methods).                                                                                                 |
+| `DecimalLike`                                       | Structural shape of an arbitrary-precision decimal value (`{ toNumber(): number; decimalPlaces(): number }`), matching e.g. Prisma's `Prisma.Decimal` without importing it directly.                | [Which fields are eligible](#which-fields-are-eligible).                                                                                                       |
 | `Primitive`                                         | Union of scalar types (`string \| number \| boolean \| bigint \| symbol \| undefined \| null \| Date`) treated as leaves — not relations — when walking an entity's shape.                           | Used by `Ordering<T>` to tell scalar fields apart from relation fields.                                                                                       |
 | `VSRepoWhere<T>`                                    | ORM-agnostic filter type accepted by `*Where` dynamic methods (e.g. `findWhere`, `findOneWhere`, `updateWhere`). Supports field filters, logical operators (`AND`/`OR`/`NOT`), and relation filters. | [`findWhere`, `findOneWhere` and other `*Where` prefixes](#available-prefixes).                                                                               |
 | `VSRepoOrmTypes`                                    | `{ dbClient; dbTransaction }` — describes your ORM's client/transaction types. Passed as the third generic to `VSRepository<Entity, PKType, OrmTypes>` to type `getDbClient()`, `transaction()` and the `db` option instead of `any`. | [Creating a repository](#creating-a-repository).                                                                                                              |
@@ -750,6 +825,51 @@ export abstract class VSRepoAdapter<T> {
         update: DeepPartial<T>,
         options?: AdapterMethodOptions<T>,
     ): Promise<T>;
+
+    abstract incrementOne<K extends NumericKeys<T>>(
+        field: K,
+        value: NonNullable<T[K]>,
+        where: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<T>;
+    abstract decrementOne<K extends NumericKeys<T>>(
+        field: K,
+        value: NonNullable<T[K]>,
+        where: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<T>;
+    abstract multiplyOne<K extends NumericKeys<T>>(
+        field: K,
+        value: NonNullable<T[K]>,
+        where: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<T>;
+    abstract divideOne<K extends NumericKeys<T>>(
+        field: K,
+        value: NonNullable<T[K]>,
+        where: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<T>;
+    abstract sum(
+        field: NumericKeys<T>,
+        where?: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<number | null>;
+    abstract average(
+        field: NumericKeys<T>,
+        where?: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<number | null>;
+    abstract min(
+        field: NumericKeys<T>,
+        where?: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<number | null>;
+    abstract max(
+        field: NumericKeys<T>,
+        where?: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<number | null>;
 }
 ```
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -39,6 +39,9 @@ O VSRepository permite criar repositories fortemente tipados com:
 - [Options do construtor](#options-do-construtor)
 - [Métodos base](#métodos-base)
 - [Soft-delete](#soft-delete)
+- [Métodos atômicos e de agregação](#métodos-atômicos-e-de-agregação)
+    - [Quais campos são elegíveis](#quais-campos-são-elegíveis)
+    - [Escrevendo um adapter](#escrevendo-um-adapter)
 - [`select` e `relations`](#select-e-relations)
 - [Métodos dinâmicos](#métodos-dinâmicos)
     - [Prefixos disponíveis](#prefixos-disponíveis)
@@ -97,7 +100,7 @@ O adapter do Prisma 7 já foi publicado no npm como `@vsrepo/prisma7-adapter` �
 
 | Adapter                                                                                  | Status                                                                                                                                                                                                                          |
 | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Prisma 7 (`@vsrepo/prisma7-adapter`)                                                     | 🟢 **Lançado** — publicado no npm, implementa todo o contrato de `VSRepoAdapter` (CRUD, relations, transactions, `merge`, logging) com testes; veja o [`VSRepoPrisma7Adapter`](https://github.com/jaobrabo123/VSRepoPrisma7Adapter) para o código-fonte e docs. |
+| Prisma 7 (`@vsrepo/prisma7-adapter`)                                                     | 🟢 **Lançado** — publicado no npm, implementa o contrato de `VSRepoAdapter` (CRUD, relations, transactions, `merge`, logging) com testes; veja o [`VSRepoPrisma7Adapter`](https://github.com/jaobrabo123/VSRepoPrisma7Adapter) para o código-fonte e docs. **Nota:** os métodos atômicos/de agregação (`incrementOne`, `decrementOne`, `multiplyOne`, `divideOne`, `sum`, `average`, `min`, `max` — veja [Métodos atômicos e de agregação](#métodos-atômicos-e-de-agregação)) foram adicionados ao contrato do `VSRepoAdapter` depois do último release desse adapter; confirme no changelog/versão dele se já implementam esses métodos antes de depender de `increment`/`sum`/etc. contra o Prisma 7. |
 | TypeORM (`@vsrepo/typeorm-adapter`)                                                      | 🟡 **Planejado, ainda não publicado.** Só foi escrito um parser de referência da cláusula `where` (`parseVSRepoWhere`) para validar o design; é o ponto de partida planejado do futuro pacote `@vsrepo/typeorm-adapter`. Contribuições da comunidade nessa frente são bem-vindas. |
 | Outros ORMs (Prisma 8, Drizzle, etc.)                                                    | 🟡 **Planejados, ainda não publicados.** Nenhum pacote oficial existe ainda — por enquanto, escreva o seu próprio adapter (veja [Escrevendo seu próprio adapter](#escrevendo-seu-próprio-adapter)) e considere publicá-lo/contribuir de volta com o projeto. |
 | Adapters customizados                                                                    | 🟢 Totalmente suportados hoje — implemente você mesmo a classe abstrata [`VSRepoAdapter`](#escrevendo-seu-próprio-adapter) para qualquer ORM/banco que precisar, no seu próprio projeto ou pacote, seguindo o mesmo formato esperado dos `@vsrepo/*-adapter`. |
@@ -231,11 +234,19 @@ Disponíveis automaticamente em toda subclasse de `VSRepository`:
 | `removeList(pks, options?)` | Remove vários registros pela primary key, retornando `{ count }`.                                                                     |
 | `total(options?)`           | Retorna o total de registros.                                                                                                         |
 | `has(pk, options?)`         | Verifica se um registro existe, retornando `boolean`.                                                                                 |
+| `increment(pk, field, value, options?)` | Adiciona `value` a um campo numérico de forma atômica. Veja [Métodos atômicos e de agregação](#métodos-atômicos-e-de-agregação). |
+| `decrement(pk, field, value, options?)` | Subtrai `value` de um campo numérico de forma atômica.                                                                    |
+| `multiply(pk, field, value, options?)`  | Multiplica um campo numérico por `value` de forma atômica.                                                                |
+| `divide(pk, field, value, options?)`    | Divide um campo numérico por `value` de forma atômica.                                                                    |
+| `sum(field, where?, options?)`          | Soma um campo numérico em todos os registros que baterem no filtro; `null` se nenhum bater.                               |
+| `average(field, where?, options?)`      | Média aritmética de um campo numérico em todos os registros que baterem no filtro; `null` se nenhum bater.                |
+| `min(field, where?, options?)`          | Valor mínimo de um campo numérico em todos os registros que baterem no filtro; `null` se nenhum bater.                    |
+| `max(field, where?, options?)`          | Valor máximo de um campo numérico em todos os registros que baterem no filtro; `null` se nenhum bater.                    |
 | `transaction(fn, options?)` | Executa `fn` dentro de uma transação nativa do ORM.                                                                                   |
 | `getDbClient()`             | Retorna a instância do client do ORM usada fora de transações.                                                                        |
 | `query<T>(query, options?)` | Executa uma instrução SQL raw diretamente contra o banco. Veja [Queries raw pontuais com `query()`](#queries-raw-pontuais-com-query). |
 
-Todos os métodos acima (exceto `transaction`, `query` e `getDbClient`, que recebem options proprias ou nenhuma) aceitam um objeto `MethodOptions<Entity, OrmTypes>` como último argumento (`select`, `relations`, `see`, `db`).
+A maioria dos métodos acima aceita um objeto `MethodOptions<Entity, OrmTypes>` como último argumento (`select`, `relations`, `see`, `db`). Alguns — `total`, `has`, `removeList`, `sum`, `average`, `min`, `max`, e os métodos em lote de soft-delete (`softRemoveList`/`restoreList`) — não retornam/moldam uma `Entity`, então aceitam o tipo mais restrito `RestrictMethodOptions<Entity, OrmTypes>` (só `see`, `db`; sem `select`/`relations`). `transaction`, `query` e `getDbClient` recebem options próprias ou nenhuma.
 
 ---
 
@@ -267,6 +278,62 @@ await userRepository.getAll({ see: "active" }); // padrão — apenas registros 
 await userRepository.getAll({ see: "removed" }); // apenas registros com soft-delete
 await userRepository.getAll({ see: "all" }); // todos, ignorando o soft-delete
 ```
+
+---
+
+## Métodos atômicos e de agregação
+
+Toda subclasse de `VSRepository` ganha 8 métodos extras para trabalhar com campos numéricos, divididos em dois grupos:
+
+**Updates atômicos** — avaliados no servidor contra o valor *atual* da linha (`UPDATE ... SET field = field + value`), não um read-modify-write feito no client:
+
+```typescript
+await userRepository.increment("user-1", "balance", 50); // balance = balance + 50
+await userRepository.decrement("user-1", "balance", 50); // balance = balance - 50
+await userRepository.multiply("user-1", "balance", 2); // balance = balance * 2
+await userRepository.divide("user-1", "balance", 4); // balance = balance / 4
+```
+
+Os quatro retornam a `Entity` atualizada e aceitam o `MethodOptions<Entity, OrmTypes>` completo (`select`, `relations`, `see`, `db`) como último argumento, igual `get`/`save`/`patch`.
+
+**Agregações** — calculadas sobre todos os registros que baterem num `where` (opcional):
+
+```typescript
+await userRepository.sum("balance"); // soma do saldo de todos os registros ativos
+await userRepository.sum("balance", { active: true }); // ...restrito por um where
+await userRepository.average("balance");
+await userRepository.min("balance");
+await userRepository.max("balance");
+```
+
+Os quatro retornam `number | null` — `null` quando nenhum registro bate no filtro, espelhando o comportamento de `SUM()`/`AVG()`/`MIN()`/`MAX()` do SQL, que retornam `NULL` (não `0`) sobre um conjunto vazio. Diferente dos métodos atômicos, eles aceitam o tipo mais restrito `RestrictMethodOptions<Entity, OrmTypes>` (só `see`, `db` — sem `select`/`relations`, já que o resultado é um número simples, não uma `Entity` moldada).
+
+Os dois grupos respeitam `softRemoveKey`/`see` do mesmo jeito que todo outro método base — `sum("balance")` só soma registros não removidos por padrão; passe `{ see: "all" }` ou `{ see: "removed" }` para mudar isso.
+
+### Quais campos são elegíveis
+
+`field` é restrito a `NumericKeys<Entity>` — chaves cujo valor (ignorando `null`/`undefined`) é um `number`, um `bigint`, ou um objeto `DecimalLike` (qualquer coisa que exponha `toNumber()` e `decimalPlaces()`, como o `Prisma.Decimal` do Prisma):
+
+```typescript
+type Product = { id: string; name: string; price: Decimal; stock: number | null };
+
+await productRepository.increment(id, "price", new Decimal(10.5)); // ok — Decimal-like
+await productRepository.increment(id, "stock", 5); // ok — campos numéricos nullable são incluídos
+await productRepository.increment(id, "name", 1); // erro de compilação — "name" não é numérico
+```
+
+`value` é tipado como `NonNullable<Entity[Field]>` — precisa bater exatamente com o tipo do próprio campo. Um campo `Decimal` espera uma instância de `Decimal`, não um `number`/`string` puro:
+
+```typescript
+await productRepository.increment(id, "price", new Decimal(10.5)); // ok
+await productRepository.increment(id, "price", 10.5); // erro de compilação — envolva: new Decimal(10.5)
+```
+
+Vale notar que vários ORMs (Drizzle, MikroORM, TypeORM) representam colunas `decimal`/`numeric` como `string` pura por padrão, para evitar perda de precisão de ponto flutuante — um campo `string` **não** satisfaz `NumericKeys<Entity>` por padrão. Configure a coluna em modo numérico (ou um transformer) nesses ORMs se quiser que o campo fique disponível para esses 8 métodos.
+
+### Escrevendo um adapter
+
+O `VSRepoAdapter` espelha as mesmas 8 operações (`incrementOne`, `decrementOne`, `multiplyOne`, `divideOne`, `sum`, `average`, `min`, `max` — veja [Escrevendo seu próprio adapter](#escrevendo-seu-próprio-adapter)). Cada adapter traduz isso para o que o ORM/banco considera "nativo": o Prisma tem um formato de update embutido (`{ field: { increment: value } }`) e uma chamada `aggregate()`; outros ORMs em geral precisam de um `QueryBuilder`/expressão `sql` raw (ex.: `SET field = field * :value`, `SELECT SUM(field) ...`). Os métodos atômicos precisam retornar o registro refletindo o estado *depois* do write — se a API de update atômico do ORM só retorna a quantidade de linhas afetadas, faça uma leitura extra em vez de devolver uma cópia desatualizada que já estava em memória.
 
 ---
 
@@ -618,6 +685,7 @@ Além dos tipos que descrevem o formato da entidade já vistos acima (`VSRepoSel
 ```typescript
 import type {
     MethodOptions,
+    RestrictMethodOptions,
     Pagination,
     Ordering,
     OrderByField,
@@ -627,6 +695,9 @@ import type {
     CountResult,
     QueryMethodArg,
     KeysOfType,
+    NumericKeys,
+    NumericLike,
+    DecimalLike,
     Primitive,
     VSRepoWhere,
     VSRepoOrmTypes,
@@ -637,7 +708,8 @@ import type {
 
 | Tipo                                                | Descrição                                                                                                                                                                                                           | Usado por                                                                                                                                                           |
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MethodOptions<T, K>`                               | Options aceitas como último argumento por todo método base e dinâmico: `select`, `relations`, `see`, `db`.                                                                                                          | [Métodos base](#métodos-base), [Métodos Dinâmicos](#métodos-dinâmicos).                                                                                             |
+| `MethodOptions<T, K>`                               | Options aceitas como último argumento pela maioria dos métodos base e dinâmicos: `select`, `relations`, `see`, `db`.                                                                                                | [Métodos base](#métodos-base), [Métodos Dinâmicos](#métodos-dinâmicos).                                                                                             |
+| `RestrictMethodOptions<T, K>`                       | `MethodOptions<T, K>` restrito, expondo só `see`/`db` — usado pelos métodos que não retornam/moldam uma `Entity` (`total`, `has`, `sum`, `average`, `min`, `max`, `removeList`, `softRemoveList`, `restoreList`). | [Métodos base](#métodos-base), [Métodos atômicos e de agregação](#métodos-atômicos-e-de-agregação).                                                                 |
 | `Pagination`                                        | `{ limit?, offset? }` aceito por `getAll` e pelos métodos dinâmicos com `Paginated`.                                                                                                                                | [Métodos base](#métodos-base), [Ordenação, paginação e distinct](#ordenação-paginação-e-distinct).                                                                  |
 | `Ordering<T>` / `OrderByField<T>` / `SortDirection` | Formato de ordenação aceito por `getAll`, `defaultOrdering` e `injectOrdering`, e pelos métodos dinâmicos com `Ordered`. Pode ser um único objeto ou um array encadeado; objetos aninhados ordenam relações to-one. | [Options do construtor](#options-do-construtor), [Options do decorador](#options-do-decorador), [Ordenação, paginação e distinct](#ordenação-paginação-e-distinct). |
 | `SeeMode`                                           | `"active" \| "removed" \| "all"` — controla a visibilidade de registros com soft-delete.                                                                                                                            | [Soft-delete](#soft-delete).                                                                                                                                        |
@@ -645,6 +717,9 @@ import type {
 | `CountResult`                                       | `{ count: number }` — o formato retornado por operações em lote.                                                                                                                                                    | `removeList`, `softRemoveList`, `restoreList`, `createManyIgnoreConflicts`.                                                                                         |
 | `QueryMethodArg<T>`                                 | `{ args?: T, db? }` — parâmetros posicionais do SQL (`$1`, `$2`, ...) e cliente de transação para o `@QueryMethod`.                                                                                                 | [Query methods (SQL raw)](#query-methods-sql-raw).                                                                                                                  |
 | `KeysOfType<T, K>`                                  | Extrai as chaves de `T` cujo tipo de valor é atribuível a `K`.                                                                                                                                                      | Restringe `pkName`, em [Options do construtor](#options-do-construtor), aos campos da entidade compatíveis com o tipo de chave primária configurado.                |
+| `NumericKeys<T>`                                    | Extrai as chaves de `T` cujo tipo de valor (ignorando `null`/`undefined`) é atribuível a `NumericLike`. Campos numéricos nullable (`number \| null`) são incluídos.                                                | Restringe `field` em [Métodos atômicos e de agregação](#métodos-atômicos-e-de-agregação) (`increment`, `sum`, etc).                                                 |
+| `NumericLike`                                       | `number \| bigint \| DecimalLike`.                                                                                                                                                                                   | [Métodos atômicos e de agregação](#métodos-atômicos-e-de-agregação).                                                                                                 |
+| `DecimalLike`                                       | Formato estrutural de um valor decimal de precisão arbitrária (`{ toNumber(): number; decimalPlaces(): number }`), compatível com o `Prisma.Decimal` do Prisma sem precisar importá-lo diretamente.                | [Quais campos são elegíveis](#quais-campos-são-elegíveis).                                                                                                           |
 | `Primitive`                                         | União de tipos escalares (`string \| number \| boolean \| bigint \| symbol \| undefined \| null \| Date`) tratados como valores-folha — e não relações — ao percorrer o formato de uma entidade.                    | Usado por `Ordering<T>` para distinguir campos escalares de campos de relação.                                                                                      |
 | `VSRepoWhere<T>`                                    | Tipo de filtro agnóstico de ORM aceito pelos métodos dinâmicos `*Where` (ex.: `findWhere`, `findOneWhere`, `updateWhere`). Suporta filtros de campo, operadores lógicos (`AND`/`OR`/`NOT`) e filtros de relação.    | [Prefixos `findWhere`, `findOneWhere` e demais `*Where`](#prefixos-disponíveis).                                                                                    |
 | `VSRepoOrmTypes`                                    | `{ dbClient; dbTransaction }` — descreve os tipos de client/transaction do seu ORM. Passado como terceiro generic de `VSRepository<Entity, PKType, OrmTypes>` para tipar `getDbClient()`, `transaction()` e a option `db` em vez de `any`. | [Criando um repository](#criando-um-repository).                                                                                                                    |
@@ -753,6 +828,51 @@ export abstract class VSRepoAdapter<T> {
         update: DeepPartial<T>,
         options?: AdapterMethodOptions<T>,
     ): Promise<T>;
+
+    abstract incrementOne<K extends NumericKeys<T>>(
+        field: K,
+        value: NonNullable<T[K]>,
+        where: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<T>;
+    abstract decrementOne<K extends NumericKeys<T>>(
+        field: K,
+        value: NonNullable<T[K]>,
+        where: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<T>;
+    abstract multiplyOne<K extends NumericKeys<T>>(
+        field: K,
+        value: NonNullable<T[K]>,
+        where: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<T>;
+    abstract divideOne<K extends NumericKeys<T>>(
+        field: K,
+        value: NonNullable<T[K]>,
+        where: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<T>;
+    abstract sum(
+        field: NumericKeys<T>,
+        where?: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<number | null>;
+    abstract average(
+        field: NumericKeys<T>,
+        where?: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<number | null>;
+    abstract min(
+        field: NumericKeys<T>,
+        where?: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<number | null>;
+    abstract max(
+        field: NumericKeys<T>,
+        where?: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<number | null>;
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsrepo",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "ORM-agnostic repository pattern library with full TypeScript support and automatic type inference.",
   "homepage": "https://github.com/jaobrabo123/VSRepository#readme",
   "repository": {

--- a/src/VSRepoAdapter.ts
+++ b/src/VSRepoAdapter.ts
@@ -139,6 +139,17 @@ export abstract class VSRepoAdapter<T> {
         options?: AdapterMethodOptions<T>,
     ): Promise<T>;
 
+    /**
+     * Atomically adds `value` to `field` on the single record matching
+     * `where` — equivalent to `UPDATE ... SET field = field + value WHERE
+     * ...`, evaluated server-side against the row's current value (not a
+     * client-side read-modify-write).
+     *
+     * Implementations must return the record reflecting the state *after*
+     * the write. If the underlying ORM's atomic-update API doesn't already
+     * return the updated row (e.g. it only returns an affected-row count),
+     * issue a follow-up read instead of returning a stale in-memory copy.
+     */
     public abstract incrementOne<K extends NumericKeys<T>>(
         field: K,
         value: NonNullable<T[K]>,
@@ -146,6 +157,7 @@ export abstract class VSRepoAdapter<T> {
         options?: AdapterMethodOptions<T>,
     ): Promise<T>;
 
+    /** Same as {@link VSRepoAdapter.incrementOne}, subtracting `value` instead of adding it. */
     public abstract decrementOne<K extends NumericKeys<T>>(
         field: K,
         value: NonNullable<T[K]>,
@@ -153,6 +165,7 @@ export abstract class VSRepoAdapter<T> {
         options?: AdapterMethodOptions<T>,
     ): Promise<T>;
 
+    /** Same as {@link VSRepoAdapter.incrementOne}, multiplying the field's current value by `value`. */
     public abstract multiplyOne<K extends NumericKeys<T>>(
         field: K,
         value: NonNullable<T[K]>,
@@ -160,6 +173,13 @@ export abstract class VSRepoAdapter<T> {
         options?: AdapterMethodOptions<T>,
     ): Promise<T>;
 
+    /**
+     * Same as {@link VSRepoAdapter.incrementOne}, dividing the field's
+     * current value by `value`. Division-by-zero behavior is not
+     * standardized by this contract — it is whatever the underlying
+     * database/driver does natively (e.g. Postgres raises a
+     * `division_by_zero` error); document your adapter's actual behavior.
+     */
     public abstract divideOne<K extends NumericKeys<T>>(
         field: K,
         value: NonNullable<T[K]>,
@@ -167,24 +187,33 @@ export abstract class VSRepoAdapter<T> {
         options?: AdapterMethodOptions<T>,
     ): Promise<T>;
 
+    /**
+     * Returns the sum of `field` across every record matching `where` (all
+     * records if `where` is omitted/empty), or `null` if no record
+     * matches — mirroring SQL's `SUM()`, which returns `NULL` (not `0`)
+     * over an empty set.
+     */
     public abstract sum(
         field: NumericKeys<T>,
         where?: VSRepoWhere<T>,
         options?: AdapterMethodOptions<T>,
     ): Promise<number | null>;
 
+    /** Same as {@link VSRepoAdapter.sum}, but the arithmetic mean (`AVG()`) instead of the total. */
     public abstract average(
         field: NumericKeys<T>,
         where?: VSRepoWhere<T>,
         options?: AdapterMethodOptions<T>,
     ): Promise<number | null>;
 
+    /** Same as {@link VSRepoAdapter.sum}, but the minimum value (`MIN()`) instead of the total. */
     public abstract min(
         field: NumericKeys<T>,
         where?: VSRepoWhere<T>,
         options?: AdapterMethodOptions<T>,
     ): Promise<number | null>;
 
+    /** Same as {@link VSRepoAdapter.sum}, but the maximum value (`MAX()`) instead of the total. */
     public abstract max(
         field: NumericKeys<T>,
         where?: VSRepoWhere<T>,

--- a/src/VSRepoAdapter.ts
+++ b/src/VSRepoAdapter.ts
@@ -2,6 +2,7 @@ import { AdapterMethodOptions } from "./types/adapter/adapter-method-options.typ
 import { AdapterQueryOptions } from "./types/adapter/adapter-query-options.type";
 import { CountResult } from "./types/utils/count-result.type";
 import { DeepPartial } from "./types/utils/deep-partial.type";
+import { NumericKeys } from "./types/utils/numeric-keys.type";
 import { VSRepoTransactionOptions } from "./types/vsrepo/vsrepo-transaction-options.type";
 import { VSRepoWhere } from "./types/vsrepo/vsrepo-where.type";
 
@@ -137,4 +138,56 @@ export abstract class VSRepoAdapter<T> {
         update: DeepPartial<T>,
         options?: AdapterMethodOptions<T>,
     ): Promise<T>;
+
+    public abstract incrementOne<K extends NumericKeys<T>>(
+        field: K,
+        value: NonNullable<T[K]>,
+        where: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<T>;
+
+    public abstract decrementOne<K extends NumericKeys<T>>(
+        field: K,
+        value: NonNullable<T[K]>,
+        where: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<T>;
+
+    public abstract multiplyOne<K extends NumericKeys<T>>(
+        field: K,
+        value: NonNullable<T[K]>,
+        where: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<T>;
+
+    public abstract divideOne<K extends NumericKeys<T>>(
+        field: K,
+        value: NonNullable<T[K]>,
+        where: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<T>;
+
+    public abstract sum(
+        field: NumericKeys<T>,
+        where?: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<number | null>;
+
+    public abstract average(
+        field: NumericKeys<T>,
+        where?: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<number | null>;
+
+    public abstract min(
+        field: NumericKeys<T>,
+        where?: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<number | null>;
+
+    public abstract max(
+        field: NumericKeys<T>,
+        where?: VSRepoWhere<T>,
+        options?: AdapterMethodOptions<T>,
+    ): Promise<number | null>;
 }

--- a/src/VSRepository.ts
+++ b/src/VSRepository.ts
@@ -19,6 +19,8 @@ import { DynamicMethodsResolver } from "./internal/resolvers/dynamic-methods.res
 import { VSRepoError } from "./errors/VSRepoError";
 import { VSRepoErrorType } from "./internal/enums/vsrepo-error-type.enum";
 import { VSRepoQueryOptions } from "./types/vsrepo/vsrepo-query-options.type";
+import { NumericKeys } from "./types/utils/numeric-keys.type";
+import { RestrictMethodOptions } from "./types/utils/restrict-method-options.type";
 
 /**
  * ORM-agnostic base repository, exposing a complete set of ready-to-use CRUD
@@ -153,11 +155,14 @@ export abstract class VSRepository<
         fn: (optionsChecked: MethodOptions<Entity, OrmTypes>) => Promise<R>,
         methodName: string,
         optionsUnchecked: unknown,
+        opsType: "common" | "getAll" | "restrict" = "common",
     ): Promise<R> {
         const optionsChecked =
-            methodName === "getAll"
-                ? this.validator.validateGetAllMethodOptions(optionsUnchecked)
-                : this.validator.validateMethodOptions(optionsUnchecked);
+            opsType === "common"
+                ? this.validator.validateMethodOptions(optionsUnchecked)
+                : opsType === "restrict"
+                  ? this.validator.validateRestrictMethodOptions(optionsUnchecked)
+                  : this.validator.validateGetAllMethodOptions(optionsUnchecked);
 
         optionsChecked.db ??= this.getDbClient();
 
@@ -305,6 +310,7 @@ export abstract class VSRepository<
                 }),
             "getAll",
             options,
+            "getAll",
         );
     }
 
@@ -344,7 +350,7 @@ export abstract class VSRepository<
     /** Deletes multiple records by their primary keys, returning the count of affected rows. */
     async removeList(
         pks: PKType[],
-        options?: MethodOptions<Entity, OrmTypes>,
+        options?: RestrictMethodOptions<Entity, OrmTypes>,
     ): Promise<CountResult> {
         if (!Array.isArray(pks)) {
             this.fail("'pks' must be a valid array", VSRepoErrorType.BASE);
@@ -358,6 +364,7 @@ export abstract class VSRepository<
                 ),
             "removeList",
             options,
+            "restrict",
         );
     }
 
@@ -402,16 +409,17 @@ export abstract class VSRepository<
     }
 
     /** Returns the total number of records. */
-    async total(options?: MethodOptions<Entity, OrmTypes>): Promise<number> {
+    async total(options?: RestrictMethodOptions<Entity, OrmTypes>): Promise<number> {
         return this.execBaseMethod(
             opt => this.adapter.count(this.mergeWheresResolver.resolve(opt.see, {}), opt),
             "total",
             options,
+            "restrict",
         );
     }
 
     /** Checks whether a record exists by its primary key (PK). */
-    async has(pk: PKType, options?: MethodOptions<Entity, OrmTypes>): Promise<boolean> {
+    async has(pk: PKType, options?: RestrictMethodOptions<Entity, OrmTypes>): Promise<boolean> {
         return this.execBaseMethod(
             opt =>
                 this.adapter.exists(
@@ -420,6 +428,7 @@ export abstract class VSRepository<
                 ),
             "has",
             options,
+            "restrict",
         );
     }
 
@@ -449,7 +458,7 @@ export abstract class VSRepository<
     /** Marks multiple records as deleted (soft-delete) in batch. Requires `softRemoveKey` to be configured on the repository. */
     async softRemoveList(
         pks: PKType[],
-        options?: MethodOptions<Entity, OrmTypes>,
+        options?: RestrictMethodOptions<Entity, OrmTypes>,
     ): Promise<CountResult> {
         if (!this.softRemoveKey) {
             this.fail(
@@ -472,6 +481,7 @@ export abstract class VSRepository<
                 ),
             "softRemoveList",
             options,
+            "restrict",
         );
     }
 
@@ -501,7 +511,7 @@ export abstract class VSRepository<
     /** Restores multiple records previously marked as deleted (soft-delete) in batch. Requires `softRemoveKey` to be configured on the repository. */
     async restoreList(
         pks: PKType[],
-        options?: MethodOptions<Entity, OrmTypes>,
+        options?: RestrictMethodOptions<Entity, OrmTypes>,
     ): Promise<CountResult> {
         if (!this.softRemoveKey) {
             this.fail(
@@ -524,6 +534,171 @@ export abstract class VSRepository<
                 ),
             "restoreList",
             options,
+            "restrict",
+        );
+    }
+
+    async increment<Field extends NumericKeys<Entity>>(
+        pk: PKType,
+        field: Field,
+        value: NonNullable<Entity[Field]>,
+        options?: MethodOptions<Entity, OrmTypes>,
+    ): Promise<Entity> {
+        this.validator.assertIsNumericLike(value);
+
+        return this.execBaseMethod(
+            opt =>
+                this.adapter.incrementOne(
+                    field,
+                    value,
+                    this.mergeWheresResolver.resolve(opt.see, this.wherePk(pk)),
+                    opt,
+                ),
+            "increment",
+            options,
+        );
+    }
+
+    async decrement<Field extends NumericKeys<Entity>>(
+        pk: PKType,
+        field: Field,
+        value: NonNullable<Entity[Field]>,
+        options?: MethodOptions<Entity, OrmTypes>,
+    ): Promise<Entity> {
+        this.validator.assertIsNumericLike(value);
+
+        return this.execBaseMethod(
+            opt =>
+                this.adapter.decrementOne(
+                    field,
+                    value,
+                    this.mergeWheresResolver.resolve(opt.see, this.wherePk(pk)),
+                    opt,
+                ),
+            "decrement",
+            options,
+        );
+    }
+
+    async multiply<Field extends NumericKeys<Entity>>(
+        pk: PKType,
+        field: Field,
+        value: NonNullable<Entity[Field]>,
+        options?: MethodOptions<Entity, OrmTypes>,
+    ): Promise<Entity> {
+        this.validator.assertIsNumericLike(value);
+
+        return this.execBaseMethod(
+            opt =>
+                this.adapter.multiplyOne(
+                    field,
+                    value,
+                    this.mergeWheresResolver.resolve(opt.see, this.wherePk(pk)),
+                    opt,
+                ),
+            "multiply",
+            options,
+        );
+    }
+
+    async divide<Field extends NumericKeys<Entity>>(
+        pk: PKType,
+        field: Field,
+        value: NonNullable<Entity[Field]>,
+        options?: MethodOptions<Entity, OrmTypes>,
+    ): Promise<Entity> {
+        this.validator.assertIsNumericLike(value);
+
+        return this.execBaseMethod(
+            opt =>
+                this.adapter.divideOne(
+                    field,
+                    value,
+                    this.mergeWheresResolver.resolve(opt.see, this.wherePk(pk)),
+                    opt,
+                ),
+            "divide",
+            options,
+        );
+    }
+
+    async sum(
+        field: NumericKeys<Entity>,
+        where?: VSRepoWhere<Entity>,
+        options?: RestrictMethodOptions<Entity, OrmTypes>,
+    ): Promise<number | null> {
+        const validatedWhere = this.validator.validateWhere(where ?? {});
+
+        return this.execBaseMethod(
+            opt =>
+                this.adapter.sum(
+                    field,
+                    this.mergeWheresResolver.resolve(opt.see, validatedWhere),
+                    opt,
+                ),
+            "sum",
+            options,
+            "restrict",
+        );
+    }
+
+    async average(
+        field: NumericKeys<Entity>,
+        where?: VSRepoWhere<Entity>,
+        options?: RestrictMethodOptions<Entity, OrmTypes>,
+    ): Promise<number | null> {
+        const validatedWhere = this.validator.validateWhere(where ?? {});
+
+        return this.execBaseMethod(
+            opt =>
+                this.adapter.average(
+                    field,
+                    this.mergeWheresResolver.resolve(opt.see, validatedWhere),
+                    opt,
+                ),
+            "average",
+            options,
+            "restrict",
+        );
+    }
+
+    async min(
+        field: NumericKeys<Entity>,
+        where?: VSRepoWhere<Entity>,
+        options?: RestrictMethodOptions<Entity, OrmTypes>,
+    ): Promise<number | null> {
+        const validatedWhere = this.validator.validateWhere(where ?? {});
+
+        return this.execBaseMethod(
+            opt =>
+                this.adapter.min(
+                    field,
+                    this.mergeWheresResolver.resolve(opt.see, validatedWhere),
+                    opt,
+                ),
+            "min",
+            options,
+            "restrict",
+        );
+    }
+
+    async max(
+        field: NumericKeys<Entity>,
+        where?: VSRepoWhere<Entity>,
+        options?: RestrictMethodOptions<Entity, OrmTypes>,
+    ): Promise<number | null> {
+        const validatedWhere = this.validator.validateWhere(where ?? {});
+
+        return this.execBaseMethod(
+            opt =>
+                this.adapter.max(
+                    field,
+                    this.mergeWheresResolver.resolve(opt.see, validatedWhere),
+                    opt,
+                ),
+            "max",
+            options,
+            "restrict",
         );
     }
 }

--- a/src/VSRepository.ts
+++ b/src/VSRepository.ts
@@ -538,6 +538,11 @@ export abstract class VSRepository<
         );
     }
 
+    /**
+     * Atomically adds `value` to a numeric field of the record identified
+     * by `pk`, evaluated server-side against the row's current value (e.g.
+     * `saldo = saldo + value`) — not a fetch-then-save round trip.
+     */
     async increment<Field extends NumericKeys<Entity>>(
         pk: PKType,
         field: Field,
@@ -559,6 +564,7 @@ export abstract class VSRepository<
         );
     }
 
+    /** Same as {@link VSRepository.increment}, subtracting `value` instead of adding it. */
     async decrement<Field extends NumericKeys<Entity>>(
         pk: PKType,
         field: Field,
@@ -580,6 +586,7 @@ export abstract class VSRepository<
         );
     }
 
+    /** Same as {@link VSRepository.increment}, multiplying the field's current value by `value`. */
     async multiply<Field extends NumericKeys<Entity>>(
         pk: PKType,
         field: Field,
@@ -601,6 +608,11 @@ export abstract class VSRepository<
         );
     }
 
+    /**
+     * Same as {@link VSRepository.increment}, dividing the field's current
+     * value by `value`. Division-by-zero behavior depends on the adapter/
+     * underlying database (see {@link VSRepoAdapter.divideOne}).
+     */
     async divide<Field extends NumericKeys<Entity>>(
         pk: PKType,
         field: Field,
@@ -622,6 +634,11 @@ export abstract class VSRepository<
         );
     }
 
+    /**
+     * Returns the sum of a numeric field across every record matching
+     * `where` (all records if omitted), or `null` if none match — mirrors
+     * SQL's `SUM()`, which returns `NULL` (not `0`) over an empty set.
+     */
     async sum(
         field: NumericKeys<Entity>,
         where?: VSRepoWhere<Entity>,
@@ -642,6 +659,7 @@ export abstract class VSRepository<
         );
     }
 
+    /** Same as {@link VSRepository.sum}, but the arithmetic mean instead of the total. */
     async average(
         field: NumericKeys<Entity>,
         where?: VSRepoWhere<Entity>,
@@ -662,6 +680,7 @@ export abstract class VSRepository<
         );
     }
 
+    /** Same as {@link VSRepository.sum}, but the minimum value instead of the total. */
     async min(
         field: NumericKeys<Entity>,
         where?: VSRepoWhere<Entity>,
@@ -682,6 +701,7 @@ export abstract class VSRepository<
         );
     }
 
+    /** Same as {@link VSRepository.sum}, but the maximum value instead of the total. */
     async max(
         field: NumericKeys<Entity>,
         where?: VSRepoWhere<Entity>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,12 @@ export type { VSRepoOptions } from "./types/vsrepo/vsrepo-options.type.js";
 export type { VSRepoOrmTypes } from "./types/vsrepo/vsrepo-orm-types.type.js";
 export type { VSRepoArgs } from "./types/vsrepo/vsrepo-args.type.js";
 export type { VSRepoMethod } from "./types/vsrepo/vsrepo-method.type.js";
-export type { VSRepoWhere, VSRepoWherePlain, VSRepoFieldWhere, VSRepoFieldOperators } from "./types/vsrepo/vsrepo-where.type.js";
+export type {
+    VSRepoWhere,
+    VSRepoWherePlain,
+    VSRepoFieldWhere,
+    VSRepoFieldOperators,
+} from "./types/vsrepo/vsrepo-where.type.js";
 export type { VSRepoRelations, RelationKeys } from "./types/vsrepo/vsrepo-relations.type.js";
 export type { VSRepoSelect } from "./types/vsrepo/vsrepo-select.type.js";
 export type { VSRepoTransactionOptions } from "./types/vsrepo/vsrepo-transaction-options.type.js";
@@ -39,6 +44,10 @@ export type { Pagination } from "./types/utils/pagination.type.js";
 export type { Primitive } from "./types/utils/primitive.type.js";
 export type { SeeMode } from "./types/utils/see-mode.type.js";
 export type { VSRepoQueryOptions } from "./types/vsrepo/vsrepo-query-options.type";
+export type { DecimalLike } from "./types/utils/decimal-like.type.js";
+export type { NumericKeys } from "./types/utils/numeric-keys.type.js";
+export type { NumericLike } from "./types/utils/numeric-like.type.js";
+export type { RestrictMethodOptions } from "./types/utils/restrict-method-options.type.js";
 
 // Internal features
-export { VSLogger } from "./internal/utils/vs-logger.util.js"
+export { VSLogger } from "./internal/utils/vs-logger.util.js";

--- a/src/internal/validators/vsrepo.validator.ts
+++ b/src/internal/validators/vsrepo.validator.ts
@@ -16,6 +16,8 @@ import paginationSchema from "./schemas/pagination.schema";
 import whereSchema from "./schemas/where.schema";
 import { VSRepoWhere } from "../../types/vsrepo/vsrepo-where.type";
 import { VSRepoQueryOptions } from "../../types/vsrepo/vsrepo-query-options.type";
+import { NumericLike } from "../../types/utils/numeric-like.type";
+import { RestrictMethodOptions } from "../../types/utils/restrict-method-options.type";
 
 export class VSRepoValidator<T, K, O extends VSRepoOrmTypes = VSRepoOrmTypes> {
     // * Setado depois pelo VSRepository, pois no momento em que validateConstructorOptions
@@ -76,6 +78,21 @@ export class VSRepoValidator<T, K, O extends VSRepoOrmTypes = VSRepoOrmTypes> {
         }
 
         return parsed.output as unknown as MethodOptions<T>;
+    }
+
+    private readonly restrictMethodOptionsSchema = v.object({
+        db: v.optional(v.any()),
+        see: v.optional(v.picklist(["active", "removed", "all"])),
+    });
+
+    validateRestrictMethodOptions(options?: unknown): RestrictMethodOptions<T, O> {
+        const parsed = v.safeParse(this.restrictMethodOptionsSchema, options ?? {});
+
+        if (!parsed.success) {
+            this.failValidation(parsed.issues[0], VSRepoErrorType.VALIDATOR);
+        }
+
+        return parsed.output as unknown as RestrictMethodOptions<T, O>;
     }
 
     private readonly getAllMethodOptionsSchema = v.object({
@@ -171,5 +188,20 @@ export class VSRepoValidator<T, K, O extends VSRepoOrmTypes = VSRepoOrmTypes> {
         }
 
         return parsed.output as VSRepoWhere<T>;
+    }
+
+    private decimalLikeSchema = v.looseObject({
+        toNumber: v.function(),
+        decimalPlaces: v.function(),
+    });
+
+    private numericLikeSchema = v.union([v.number(), v.bigint(), this.decimalLikeSchema]);
+
+    assertIsNumericLike(value: unknown): asserts value is NumericLike {
+        const parsed = v.safeParse(this.numericLikeSchema, value);
+
+        if (!parsed.success) {
+            this.failValidation(parsed.issues[0], VSRepoErrorType.VALIDATOR);
+        }
     }
 }

--- a/src/types/utils/decimal-like.type.ts
+++ b/src/types/utils/decimal-like.type.ts
@@ -1,4 +1,20 @@
 /**
+ * Structural shape of an arbitrary-precision "Decimal" value, as commonly
+ * returned by ORMs for `decimal`/`numeric` columns (e.g. Prisma's
+ * `Prisma.Decimal`, built on top of `decimal.js`).
+ *
+ * Matched structurally (duck-typed) instead of importing a concrete class,
+ * so the core stays ORM-agnostic — any object exposing both `toNumber()`
+ * and `decimalPlaces()` is treated as Decimal-like by {@link NumericLike}
+ * and, transitively, by {@link NumericKeys}.
+ *
+ * Note that several ORMs (e.g. Drizzle, MikroORM, TypeORM) represent
+ * `decimal`/`numeric` columns as plain `string` by default, to avoid
+ * floating-point precision loss — a `string` value does **not** satisfy
+ * `DecimalLike`. Configure the column in a numeric mode (or provide a
+ * transformer) on those ORMs if you want the field to be eligible for
+ * `increment`/`decrement`/`multiply`/`divide`/`sum`/`average`/`min`/`max`.
+ *
  * @publicApi
  */
 export type DecimalLike = {

--- a/src/types/utils/decimal-like.type.ts
+++ b/src/types/utils/decimal-like.type.ts
@@ -1,0 +1,7 @@
+/**
+ * @publicApi
+ */
+export type DecimalLike = {
+    toNumber(): number;
+    decimalPlaces(): number;
+};

--- a/src/types/utils/numeric-keys.type.ts
+++ b/src/types/utils/numeric-keys.type.ts
@@ -1,0 +1,8 @@
+import { NumericLike } from "./numeric-like.type";
+
+/**
+ * @publicApi
+ */
+export type NumericKeys<T> = {
+    [P in keyof T]: NonNullable<T[P]> extends NumericLike ? P : never;
+}[keyof T];

--- a/src/types/utils/numeric-keys.type.ts
+++ b/src/types/utils/numeric-keys.type.ts
@@ -1,6 +1,23 @@
 import { NumericLike } from "./numeric-like.type";
 
 /**
+ * Extracts the keys of `T` whose (non-nullable) value type is assignable to
+ * {@link NumericLike} — i.e. the fields eligible as the `field` argument of
+ * `increment`/`decrement`/`multiply`/`divide`/`sum`/`average`/`min`/`max`.
+ *
+ * Nullable/optional numeric fields (e.g. `number | null`) ARE included —
+ * the `null`/`undefined` part is stripped before the check, it isn't a
+ * reason to exclude the field. This means a field that is currently `NULL`
+ * in the database can be targeted; be aware that in standard SQL, arithmetic
+ * against a `NULL` value (`NULL + 5`) itself stays `NULL` — this type only
+ * governs what compiles, not the row's runtime value.
+ *
+ * @example
+ * ```typescript
+ * type Product = { id: string; price: Decimal; stock: number | null; name: string };
+ * type Numeric = NumericKeys<Product>; // "price" | "stock"
+ * ```
+ *
  * @publicApi
  */
 export type NumericKeys<T> = {

--- a/src/types/utils/numeric-like.type.ts
+++ b/src/types/utils/numeric-like.type.ts
@@ -1,0 +1,6 @@
+import { DecimalLike } from "./decimal-like.type";
+
+/**
+ * @publicApi
+ */
+export type NumericLike = number | bigint | DecimalLike;

--- a/src/types/utils/numeric-like.type.ts
+++ b/src/types/utils/numeric-like.type.ts
@@ -1,6 +1,11 @@
 import { DecimalLike } from "./decimal-like.type";
 
 /**
+ * Union of value types accepted as "numeric" by the atomic
+ * (`increment`/`decrement`/`multiply`/`divide`) and aggregate
+ * (`sum`/`average`/`min`/`max`) operations: a native `number`, a native
+ * `bigint`, or a {@link DecimalLike} object.
+ *
  * @publicApi
  */
 export type NumericLike = number | bigint | DecimalLike;

--- a/src/types/utils/primitive.type.ts
+++ b/src/types/utils/primitive.type.ts
@@ -1,6 +1,17 @@
+import { DecimalLike } from "./decimal-like.type";
+
 /**
  * Types treated as scalar (non-relation) values when walking an entity's shape.
  *
  * @publicApi
  */
-export type Primitive = string | number | boolean | bigint | symbol | undefined | null | Date;
+export type Primitive =
+    | string
+    | number
+    | boolean
+    | bigint
+    | symbol
+    | undefined
+    | null
+    | Date
+    | DecimalLike;

--- a/src/types/utils/restrict-method-options.type.ts
+++ b/src/types/utils/restrict-method-options.type.ts
@@ -2,6 +2,14 @@ import { VSRepoOrmTypes } from "../vsrepo/vsrepo-orm-types.type";
 import { MethodOptions } from "./methods-options.type";
 
 /**
+ * Narrowed variant of {@link MethodOptions} exposing only `db` and `see`.
+ *
+ * Used by base methods that don't shape/return an `Entity` — count-like
+ * operations (`total`, `has`, `sum`, `average`, `min`, `max`) and
+ * batch-delete-like operations (`removeList`, `softRemoveList`,
+ * `restoreList`) — where `select`/`relations` (which only make sense when
+ * an `Entity` is being returned) don't apply.
+ *
  * @publicApi
  */
 export type RestrictMethodOptions<T, O extends VSRepoOrmTypes = VSRepoOrmTypes> = Pick<

--- a/src/types/utils/restrict-method-options.type.ts
+++ b/src/types/utils/restrict-method-options.type.ts
@@ -1,0 +1,10 @@
+import { VSRepoOrmTypes } from "../vsrepo/vsrepo-orm-types.type";
+import { MethodOptions } from "./methods-options.type";
+
+/**
+ * @publicApi
+ */
+export type RestrictMethodOptions<T, O extends VSRepoOrmTypes = VSRepoOrmTypes> = Pick<
+    MethodOptions<T, O>,
+    "db" | "see"
+>;

--- a/test/helpers/entities.ts
+++ b/test/helpers/entities.ts
@@ -38,6 +38,8 @@ export type User = {
     userType: UserType;
     active: boolean;
     likesVSRepo: boolean;
+    balance: number;
+    bonusPoints: number | null;
     createdAt: Date;
     updatedAt: Date;
     deletedAt?: Date | null;
@@ -54,6 +56,8 @@ export function buildUser(overrides: Partial<User> = {}): User {
         userType: UserType.COMMON,
         active: true,
         likesVSRepo: true,
+        balance: 100,
+        bonusPoints: null,
         createdAt: new Date("2026-01-01T00:00:00.000Z"),
         updatedAt: new Date("2026-01-01T00:00:00.000Z"),
         ...overrides,

--- a/test/helpers/fake-adapter.ts
+++ b/test/helpers/fake-adapter.ts
@@ -41,6 +41,14 @@ export function createFakeAdapter<T = any>(): jest.Mocked<VSRepoAdapter<T>> {
         exists: jest.fn(),
         merge: jest.fn(),
         upsert: jest.fn(),
+        incrementOne: jest.fn(),
+        decrementOne: jest.fn(),
+        multiplyOne: jest.fn(),
+        divideOne: jest.fn(),
+        sum: jest.fn(),
+        average: jest.fn(),
+        min: jest.fn(),
+        max: jest.fn(),
     } as unknown as jest.Mocked<VSRepoAdapter<T>>;
 
     return adapter;

--- a/test/implementation/atomic-and-aggregate-methods.test.ts
+++ b/test/implementation/atomic-and-aggregate-methods.test.ts
@@ -1,0 +1,203 @@
+// Testes dos 8 métodos novos (`increment`, `decrement`, `multiply`, `divide`,
+// `sum`, `average`, `min`, `max`), no mesmo espírito de `base-methods.test.ts`:
+// verifica QUAIS métodos do `VSRepoAdapter` são chamados e COM QUAIS
+// argumentos (`field`, `value`, `where` já resolvido com soft-delete,
+// `options`), sem precisar de um banco ou ORM real.
+
+import "reflect-metadata";
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import { VSRepository } from "../../src/VSRepository";
+import { VSRepoAdapter } from "../../src/VSRepoAdapter";
+import { createFakeAdapter } from "../helpers/fake-adapter";
+import { User, buildUser } from "../helpers/entities";
+
+class UserRepository extends VSRepository<User, string> {
+    constructor(adapter: VSRepoAdapter<User>) {
+        super({ adapter, pkName: "id" });
+    }
+}
+
+// Mesma entidade, mas com `softRemoveKey` configurado — usada para confirmar
+// que `increment`/`sum`/etc. também respeitam o filtro automático de
+// soft-delete, do mesmo jeito que `get`/`total` já respeitam.
+class SoftDeletableUserRepository extends VSRepository<User, string> {
+    constructor(adapter: VSRepoAdapter<User>) {
+        super({ adapter, pkName: "id", softRemoveKey: "deletedAt" });
+    }
+}
+
+let fakeAdapter: jest.Mocked<VSRepoAdapter<User>>;
+let userRepository: UserRepository;
+
+beforeEach(() => {
+    fakeAdapter = createFakeAdapter<User>();
+    userRepository = new UserRepository(fakeAdapter);
+});
+
+describe("increment / decrement / multiply / divide", () => {
+    it("'increment' delega para 'adapter.incrementOne' com 'field', 'value' e 'where: { id: pk }'", async () => {
+        const updated = buildUser({ balance: 150 });
+        fakeAdapter.incrementOne.mockResolvedValueOnce(updated);
+
+        const result = await userRepository.increment("user-1", "balance", 50);
+
+        expect(fakeAdapter.incrementOne).toHaveBeenCalledTimes(1);
+        const [field, value, where] = fakeAdapter.incrementOne.mock.calls[0]!;
+        expect(field).toBe("balance");
+        expect(value).toBe(50);
+        expect(where).toEqual({ id: "user-1" });
+        expect(result).toBe(updated);
+    });
+
+    it("'decrement' delega para 'adapter.decrementOne'", async () => {
+        const updated = buildUser({ balance: 50 });
+        fakeAdapter.decrementOne.mockResolvedValueOnce(updated);
+
+        const result = await userRepository.decrement("user-1", "balance", 50);
+
+        expect(fakeAdapter.decrementOne).toHaveBeenCalledTimes(1);
+        const [field, value, where] = fakeAdapter.decrementOne.mock.calls[0]!;
+        expect(field).toBe("balance");
+        expect(value).toBe(50);
+        expect(where).toEqual({ id: "user-1" });
+        expect(result).toBe(updated);
+    });
+
+    it("'multiply' delega para 'adapter.multiplyOne'", async () => {
+        const updated = buildUser({ balance: 200 });
+        fakeAdapter.multiplyOne.mockResolvedValueOnce(updated);
+
+        const result = await userRepository.multiply("user-1", "balance", 2);
+
+        expect(fakeAdapter.multiplyOne).toHaveBeenCalledTimes(1);
+        const [field, value, where] = fakeAdapter.multiplyOne.mock.calls[0]!;
+        expect(field).toBe("balance");
+        expect(value).toBe(2);
+        expect(where).toEqual({ id: "user-1" });
+        expect(result).toBe(updated);
+    });
+
+    it("'divide' delega para 'adapter.divideOne'", async () => {
+        const updated = buildUser({ balance: 25 });
+        fakeAdapter.divideOne.mockResolvedValueOnce(updated);
+
+        const result = await userRepository.divide("user-1", "balance", 4);
+
+        expect(fakeAdapter.divideOne).toHaveBeenCalledTimes(1);
+        const [field, value, where] = fakeAdapter.divideOne.mock.calls[0]!;
+        expect(field).toBe("balance");
+        expect(value).toBe(4);
+        expect(where).toEqual({ id: "user-1" });
+        expect(result).toBe(updated);
+    });
+
+    it("aceita um campo numérico nullable (ex: 'bonusPoints')", async () => {
+        const updated = buildUser({ bonusPoints: 10 });
+        fakeAdapter.incrementOne.mockResolvedValueOnce(updated);
+
+        await userRepository.increment("user-1", "bonusPoints", 10);
+
+        expect(fakeAdapter.incrementOne.mock.calls[0]?.[0]).toBe("bonusPoints");
+    });
+
+    it("propaga 'options' (ex: 'select') para o adapter", async () => {
+        fakeAdapter.incrementOne.mockResolvedValueOnce(buildUser());
+
+        await userRepository.increment("user-1", "balance", 50, {
+            select: { id: true, balance: true },
+        });
+
+        const options = fakeAdapter.incrementOne.mock.calls[0]?.[3];
+        expect(options?.select).toEqual({ id: true, balance: true });
+    });
+
+    it("respeita 'softRemoveKey': só incrementa registros ativos por padrão", async () => {
+        const softDeletableRepo = new SoftDeletableUserRepository(fakeAdapter);
+        fakeAdapter.incrementOne.mockResolvedValueOnce(buildUser());
+
+        await softDeletableRepo.increment("user-1", "balance", 50);
+
+        const where = fakeAdapter.incrementOne.mock.calls[0]?.[2];
+        expect(where).toEqual({ id: "user-1", deletedAt: null });
+    });
+
+    it("com 'see: \"all\"', ignora o filtro de soft-delete", async () => {
+        const softDeletableRepo = new SoftDeletableUserRepository(fakeAdapter);
+        fakeAdapter.incrementOne.mockResolvedValueOnce(buildUser());
+
+        await softDeletableRepo.increment("user-1", "balance", 50, { see: "all" });
+
+        const where = fakeAdapter.incrementOne.mock.calls[0]?.[2];
+        expect(where).toEqual({ id: "user-1" });
+    });
+});
+
+describe("sum / average / min / max", () => {
+    it("'sum' delega para 'adapter.sum' com 'field' e 'where' vazio por padrão", async () => {
+        fakeAdapter.sum.mockResolvedValueOnce(1000);
+
+        const result = await userRepository.sum("balance");
+
+        expect(fakeAdapter.sum).toHaveBeenCalledTimes(1);
+        const [field, where] = fakeAdapter.sum.mock.calls[0]!;
+        expect(field).toBe("balance");
+        expect(where).toEqual({});
+        expect(result).toBe(1000);
+    });
+
+    it("'sum' repassa um 'where' explícito para o adapter", async () => {
+        fakeAdapter.sum.mockResolvedValueOnce(500);
+
+        await userRepository.sum("balance", { active: true });
+
+        expect(fakeAdapter.sum.mock.calls[0]?.[1]).toEqual({ active: true });
+    });
+
+    it("'sum' retorna 'null' quando o adapter não encontra nenhum registro", async () => {
+        fakeAdapter.sum.mockResolvedValueOnce(null);
+
+        const result = await userRepository.sum("balance");
+
+        expect(result).toBeNull();
+    });
+
+    it("'average' delega para 'adapter.average'", async () => {
+        fakeAdapter.average.mockResolvedValueOnce(42.5);
+
+        const result = await userRepository.average("balance");
+
+        expect(fakeAdapter.average).toHaveBeenCalledTimes(1);
+        expect(fakeAdapter.average.mock.calls[0]?.[0]).toBe("balance");
+        expect(result).toBe(42.5);
+    });
+
+    it("'min' delega para 'adapter.min'", async () => {
+        fakeAdapter.min.mockResolvedValueOnce(0);
+
+        const result = await userRepository.min("balance");
+
+        expect(fakeAdapter.min).toHaveBeenCalledTimes(1);
+        expect(fakeAdapter.min.mock.calls[0]?.[0]).toBe("balance");
+        expect(result).toBe(0);
+    });
+
+    it("'max' delega para 'adapter.max'", async () => {
+        fakeAdapter.max.mockResolvedValueOnce(9999);
+
+        const result = await userRepository.max("balance");
+
+        expect(fakeAdapter.max).toHaveBeenCalledTimes(1);
+        expect(fakeAdapter.max.mock.calls[0]?.[0]).toBe("balance");
+        expect(result).toBe(9999);
+    });
+
+    it("respeita 'softRemoveKey': só agrega registros ativos por padrão", async () => {
+        const softDeletableRepo = new SoftDeletableUserRepository(fakeAdapter);
+        fakeAdapter.sum.mockResolvedValueOnce(1000);
+
+        await softDeletableRepo.sum("balance");
+
+        const where = fakeAdapter.sum.mock.calls[0]?.[1];
+        expect(where).toEqual({ deletedAt: null });
+    });
+});

--- a/test/implementation/base-methods.test.ts
+++ b/test/implementation/base-methods.test.ts
@@ -90,7 +90,7 @@ describe("save / saveList / patch", () => {
         const saved = buildUser({ name: "Maria", email: "maria@email.com" });
         fakeAdapter.save.mockResolvedValueOnce(saved);
 
-        const result = await userRepository.save(payload as any);
+        const result = await userRepository.save(payload);
 
         expect(fakeAdapter.save).toHaveBeenCalledWith(payload, expect.anything());
         expect(result).toBe(saved);
@@ -100,7 +100,7 @@ describe("save / saveList / patch", () => {
         const payload = [{ name: "Maria" }, { name: "João" }];
         fakeAdapter.saveMany.mockResolvedValueOnce([buildUser(), buildUser()]);
 
-        await userRepository.saveList(payload as any);
+        await userRepository.saveList(payload);
 
         expect(fakeAdapter.saveMany).toHaveBeenCalledWith(payload, expect.anything());
     });
@@ -113,7 +113,7 @@ describe("save / saveList / patch", () => {
         const patched = buildUser({ name: "Novo nome" });
         fakeAdapter.update.mockResolvedValueOnce(patched);
 
-        const result = await userRepository.patch("user-1", { name: "Novo nome" } as any);
+        const result = await userRepository.patch("user-1", { name: "Novo nome" });
 
         expect(fakeAdapter.update).toHaveBeenCalledWith(
             { id: "user-1" },
@@ -172,9 +172,9 @@ describe("total / has / merge", () => {
 
     it("'merge' delega para 'adapter.merge' sem persistir nada", async () => {
         const merged = { ...buildUser(), name: "Nome atualizado" };
-        fakeAdapter.merge.mockResolvedValueOnce(merged as any);
+        fakeAdapter.merge.mockResolvedValueOnce(merged);
 
-        const result = await userRepository.merge("user-1", { name: "Nome atualizado" } as any);
+        const result = await userRepository.merge("user-1", { name: "Nome atualizado" });
 
         expect(fakeAdapter.merge).toHaveBeenCalledWith(
             { id: "user-1" },

--- a/test/implementation/soft-delete.test.ts
+++ b/test/implementation/soft-delete.test.ts
@@ -31,9 +31,7 @@ describe("sem 'softRemoveKey' configurado", () => {
     it("'softRemove' rejeita informando que o repository não tem 'softRemoveKey'", async () => {
         const userRepository = new UserRepository(fakeAdapter);
 
-        await expect(userRepository.softRemove("user-1")).rejects.toThrow(
-            /softRemoveKey/,
-        );
+        await expect(userRepository.softRemove("user-1")).rejects.toThrow(/softRemoveKey/);
     });
 
     it("'restoreList' rejeita informando que o repository não tem 'softRemoveKey'", async () => {
@@ -52,7 +50,7 @@ describe("com 'softRemoveKey' configurado", () => {
 
         const [where, data] = fakeAdapter.update.mock.calls[0]!;
         expect(where).toEqual({ id: "user-1" });
-        expect((data as any).deletedAt).toBeInstanceOf(Date);
+        expect(data.deletedAt).toBeInstanceOf(Date);
     });
 
     it("'restore' faz 'update' setando a chave configurada para 'null'", async () => {
@@ -62,7 +60,7 @@ describe("com 'softRemoveKey' configurado", () => {
         await softDeletable.restore("user-1");
 
         const [, data] = fakeAdapter.update.mock.calls[0]!;
-        expect((data as any).deletedAt).toBeNull();
+        expect(data.deletedAt).toBeNull();
     });
 
     it("'softRemoveList' faz 'updateMany' para todas as PKs informadas", async () => {
@@ -73,7 +71,7 @@ describe("com 'softRemoveKey' configurado", () => {
 
         const [where, data] = fakeAdapter.updateMany.mock.calls[0]!;
         expect(where).toEqual({ id: { in: ["user-1", "user-2"] } });
-        expect((data as any).deletedAt).toBeInstanceOf(Date);
+        expect(data.deletedAt).toBeInstanceOf(Date);
         expect(result).toEqual({ count: 2 });
     });
 

--- a/test/implementation/transactions.test.ts
+++ b/test/implementation/transactions.test.ts
@@ -11,6 +11,7 @@ import { VSRepository } from "../../src/VSRepository";
 import { VSRepoAdapter } from "../../src/VSRepoAdapter";
 import { createFakeAdapter } from "../helpers/fake-adapter";
 import { User, buildUser } from "../helpers/entities";
+import { TransactionIsolationLevel } from "../../src";
 
 class UserRepository extends VSRepository<User, string> {
     constructor(adapter: VSRepoAdapter<User>) {
@@ -32,12 +33,12 @@ describe("transaction()", () => {
         fakeAdapter.runInTransaction.mockImplementationOnce((f: any) => f("fake-tx"));
 
         const result = await userRepository.transaction(fn, {
-            isolationLevel: "Serializable" as any,
+            isolationLevel: TransactionIsolationLevel.SERIALIZABLE,
         });
 
         expect(fakeAdapter.runInTransaction).toHaveBeenCalledWith(
             fn,
-            expect.objectContaining({ isolationLevel: "Serializable" }),
+            expect.objectContaining({ isolationLevel: TransactionIsolationLevel.SERIALIZABLE }),
         );
         expect(fn).toHaveBeenCalledWith("fake-tx");
         expect(result).toBe("fake-tx");
@@ -59,9 +60,7 @@ describe("compartilhando o client de transação via 'options.db'", () => {
         await userRepository.get("user-1", { db: tx });
 
         expect(fakeAdapter.getDbClient).not.toHaveBeenCalled();
-        expect(fakeAdapter.findOne.mock.calls[0]?.[1]).toEqual(
-            expect.objectContaining({ db: tx }),
-        );
+        expect(fakeAdapter.findOne.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ db: tx }));
     });
 
     it("sem 'options.db', busca o client padrão via 'adapter.getDbClient()'", async () => {

--- a/test/typing/atomic-and-aggregate-methods.types.ts
+++ b/test/typing/atomic-and-aggregate-methods.types.ts
@@ -1,0 +1,66 @@
+// Testes de tipagem (compile-time only) dos 8 métodos novos. Não são
+// executados pelo Jest — só precisam compilar limpo com `tsc --noEmit`
+// (ver `npm run test:typing`). Cada bloco `@ts-expect-error` documenta um
+// uso que DEVE falhar a compilar; se o comentário ficar "sem efeito" (ou
+// seja, a linha abaixo dele passar a compilar de verdade), o `tsc` acusa
+// erro TS2578 e o `test:typing` quebra — funcionando como asserção.
+
+import { VSRepository } from "../../src/VSRepository";
+import { VSRepoAdapter } from "../../src/VSRepoAdapter";
+import { User } from "../helpers/entities";
+
+declare const userRepository: VSRepository<User, string>;
+declare const adapter: VSRepoAdapter<User>;
+
+// Tudo dentro de uma função async nunca chamada — só precisa compilar, não
+// rodar (o arquivo é CommonJS, então `await` de topo de arquivo não é válido).
+async function typeChecks(): Promise<void> {
+    // --- 'field' só aceita chaves numéricas (NumericKeys<Entity>) ----------
+
+    await userRepository.increment("user-1", "balance", 10); // ok — number
+    await userRepository.increment("user-1", "bonusPoints", 10); // ok — number | null (nullable incluído)
+
+    // @ts-expect-error "name" é string, não é NumericKeys<User>
+    await userRepository.increment("user-1", "name", 10);
+
+    // @ts-expect-error "address" é uma relação, não é NumericKeys<User>
+    await userRepository.increment("user-1", "address", 10);
+
+    await userRepository.sum("balance"); // ok
+    // @ts-expect-error "email" não é NumericKeys<User>
+    await userRepository.sum("email");
+
+    // --- 'value' precisa bater com o tipo do campo --------------------------
+
+    // @ts-expect-error 'value' precisa ser 'number' (tipo de 'balance'), não 'string'
+    await userRepository.increment("user-1", "balance", "10");
+
+    // --- 'options' de sum/average/min/max não aceita 'select'/'relations' --
+    // (RestrictMethodOptions só expõe 'db'/'see' — select/relations não
+    // fazem sentido para um retorno 'number | null')
+
+    // @ts-expect-error 'select' não existe em RestrictMethodOptions
+    await userRepository.sum("balance", {}, { select: { id: true } });
+
+    // @ts-expect-error 'relations' não existe em RestrictMethodOptions
+    await userRepository.average("balance", {}, { relations: {} });
+
+    // 'increment'/'decrement'/'multiply'/'divide' continuam com
+    // MethodOptions completo (aceitam 'select'/'relations'), diferente de
+    // sum/average/min/max:
+    await userRepository.increment("user-1", "balance", 10, {
+        select: { id: true, balance: true },
+    });
+
+    // --- Contrato do adapter espelha as mesmas constraints ------------------
+
+    await adapter.incrementOne("balance", 10, { id: "user-1" });
+    // @ts-expect-error "name" não é NumericKeys<User>
+    await adapter.incrementOne("name", "x", { id: "user-1" });
+
+    await adapter.sum("balance");
+    // @ts-expect-error "name" não é NumericKeys<User>
+    await adapter.sum("name");
+}
+
+void typeChecks;


### PR DESCRIPTION
This pull request introduces version 2.1.0 with significant new features and improvements, especially around numeric operations on repositories. The main additions are atomic update methods (like `increment`, `decrement`) and aggregation methods (`sum`, `average`, etc.), along with new types and contract changes for adapter authors. The documentation has been updated to explain these features, their usage, and their impact on adapter implementers.

**New Features: Atomic and Aggregate Methods**
- Added 8 new methods to `VSRepository`: atomic updates (`increment`, `decrement`, `multiply`, `divide`) that perform server-side numeric changes, and aggregation methods (`sum`, `average`, `min`, `max`) to compute values across records. Each method is type-safe and documented, with runtime validation for numeric inputs. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R284-R339) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R237-R249)

**Adapter Contract and Type Additions**
- The `VSRepoAdapter` contract now includes 8 new abstract methods corresponding to the new repository methods. This is a breaking change for custom adapters, which must implement them to be compatible with v2.1.0.
- Introduced new public types: `NumericKeys<T>`, `NumericLike`, `DecimalLike`, and `RestrictMethodOptions` to support the new features and improve type safety. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R685) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R695-R697) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L637-R719)

**Documentation Updates**
- Expanded the `README.md` with a new section on atomic and aggregate methods, eligibility rules for numeric fields, adapter authoring guidance, and updated method tables to include the new features. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R284-R339) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R237-R249)
- Clarified that some methods now accept the narrowed `RestrictMethodOptions` instead of the full `MethodOptions`, reflecting that they don't shape/return an `Entity`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R237-R249) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L637-R719)

**Adapter Compatibility Notice**
- Added a prominent note that the Prisma 7 adapter does not yet implement the new atomic/aggregate methods, and users should check the adapter version before relying on them.

**Housekeeping**
- Removed the legacy `v1` folder from the main branch, with references updated to point to the dedicated `v1` branch.

These changes make working with numeric fields more powerful and type-safe, but adapter authors must update their implementations to maintain compatibility.