### PR TITLE
Single result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to this project will be documented in this file.
 
 ---
  
+## [2.2.0] - 2026-09-06
+
+### Added
+- **`singleResult` option** on `@QueryMethod` and `query()` — collapses an array result into its first element (`null` if the array is empty) instead of leaving it as an array. Has no effect on non-array results (e.g. a `modifying` query's affected-row count). Useful for queries known to return at most one row (a `SELECT ... LIMIT 1` or a lookup by a unique column)
+- **`spreadArgs` option** on `@QueryMethod` — receive SQL placeholder values as separate positional arguments (`method(a, b, c)`), JpaRepository style, instead of a single `QueryMethodArg` object (`method({ args: [a, b, c] })`). Calling a method declared without `spreadArgs` using more than one argument now throws a `VSRepoError` (`type: VALIDATOR`), since the single-object call style is expected instead
+- **`DbArg<T>` / `withDb()`** — wrap a database client or transaction (`withDb(tx)`) to pass it as the trailing argument of a `spreadArgs` call, running that query against `tx` instead of the repository's default client. Recognized via `instanceof`, so it never collides with a regular positional argument, even one that happens to be an object
+- New public type `QueryArgs<T, O>` — types the spread parameter list of a `@QueryMethod` declared with `{ spreadArgs: true }`: `T`'s values in order, followed by an optional trailing `DbArg<O>`
+- Implementation tests covering `singleResult` and `spreadArgs` (including the `DbArg`/`withDb` extraction and the call-arity guard), plus README docs and JSDoc for every new option, type and function
+
+### Changed
+- `QueryMethodOptions.modifying` is now optional (defaults to `false` at runtime, matching the decorator's existing behavior when `options` is omitted entirely) — previously required at the type level even though omitting it worked fine
+
+---
+
+## [2.2.0] - 2026-09-06 (Português)
+
+### Adicionado
+- **Option `singleResult`** no `@QueryMethod` e no `query()` — transforma um resultado em array no seu primeiro elemento (`null` se o array estiver vazio) em vez de deixá-lo como array. Não tem efeito em resultados que não são array (ex.: o número de linhas afetadas de uma query `modifying`). Útil para queries que já se sabe que retornam no máximo uma linha (um `SELECT ... LIMIT 1` ou uma busca por uma coluna única)
+- **Option `spreadArgs`** no `@QueryMethod` — recebe os valores dos placeholders SQL como argumentos posicionais separados (`method(a, b, c)`), no estilo do JpaRepository, em vez de um único objeto `QueryMethodArg` (`method({ args: [a, b, c] })`). Chamar um método declarado sem `spreadArgs` usando mais de um argumento agora lança um `VSRepoError` (`type: VALIDATOR`), já que o estilo de chamada com objeto único é o esperado
+- **`DbArg<T>` / `withDb()`** — embrulha um client ou transação do banco (`withDb(tx)`) para passá-lo como argumento final de uma chamada com `spreadArgs`, rodando aquela query contra `tx` em vez do client padrão do repository. Reconhecido via `instanceof`, então nunca é confundido com um argumento posicional comum, mesmo que esse argumento seja um objeto
+- Novo tipo público `QueryArgs<T, O>` — tipa a lista de parâmetros via spread de um `@QueryMethod` declarado com `{ spreadArgs: true }`: os valores de `T`, em ordem, seguidos de um `DbArg<O>` opcional
+- Testes de implementação cobrindo `singleResult` e `spreadArgs` (incluindo a extração de `DbArg`/`withDb` e o guard de arity da chamada), além de documentação nos READMEs e JSDoc para cada nova option, tipo e função
+
+### Alterado
+- `QueryMethodOptions.modifying` agora é opcional (default `false` em runtime, alinhado ao comportamento já existente do decorator quando `options` é omitido por completo) — antes era obrigatório no nível de tipos, mesmo que omiti-lo já funcionasse normalmente
+
+---
+
 ## [2.1.0] - 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -976,7 +976,7 @@ try {
 | ----------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `DECORATOR`       | Invalid arguments were passed to `@DynamicMethod` or `@QueryMethod`.                                                       |
 | `RESOLVER`        | The library failed to resolve a dynamic/query method's configuration into a callable method (e.g. an unknown method name). |
-| `DYNAMIC`         | A resolved dynamic method failed at runtime (e.g. missing arguments).                                                      |
+| `DYNAMIC`         | A resolved dynamic/query method failed at runtime (e.g. missing arguments).                                                      |
 | `VALIDATOR`       | Invalid method options or arguments were detected during validation.                                                       |
 | `BASE`            | Invalid usage of a base method (`get`, `save`, `remove`, etc).                                                             |
 | `ADAPTER`         | A `VSRepoAdapter` failed while talking to the underlying ORM/database — always thrown as `VSRepoAdapterError`.             |

--- a/README.md
+++ b/README.md
@@ -598,12 +598,18 @@ class UserRepository extends VSRepository<User, string> {
 
     @QueryMethod('UPDATE "user" SET active = true WHERE id = $1', { modifying: true })
     declare activateUser: (arg: QueryMethodArg<[id: string]>) => Promise<number>;
+
+    // Only one row is ever expected here, so `singleResult` collapses the
+    // array into a single object (or `null` when no row matches).
+    @QueryMethod('SELECT * FROM "user" WHERE id = $1 LIMIT 1', { singleResult: true })
+    declare findByIdRaw: (arg: QueryMethodArg<[id: string]>) => Promise<User | null>;
 }
 ```
 
-| Option      | Type      | Default | Description                                                                                                                                                                          |
-| ----------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `modifying` | `boolean` | `false` | When `true`, runs as `INSERT`/`UPDATE`/`DELETE` and the method resolves to the number of affected rows. When `false`, runs as a read query and resolves to the declared return type. |
+| Option         | Type      | Default | Description                                                                                                                                                                          |
+| -------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `modifying`    | `boolean` | `false` | When `true`, runs as `INSERT`/`UPDATE`/`DELETE` and the method resolves to the number of affected rows. When `false`, runs as a read query and resolves to the declared return type. |
+| `singleResult` | `boolean` | `false` | When `true`, collapses an array result into its first element (`null` if empty), so you can declare the return type as a single object instead of an array. Has no effect on non-array results (e.g. a `modifying` query's affected-row count). |
 
 Query methods accept `{ args, db? }` at the call site — `db` lets them participate in a `transaction()` block just like base and dynamic methods.
 
@@ -612,7 +618,7 @@ Query methods accept `{ args, db? }` at the call site — `db` lets them partici
 For one-off raw SQL that doesn't warrant declaring a `@QueryMethod` on the repository class, call `query()` directly — it's available on every `VSRepository` instance and goes through the same adapter's `query()` implementation under the hood:
 
 ```typescript
-query<T = any>(query: string, options?: { args?: any[]; db?: any; modifying?: boolean }): Promise<T>;
+query<T = any>(query: string, options?: { args?: any[]; db?: any; modifying?: boolean; singleResult?: boolean }): Promise<T>;
 ```
 
 ```typescript
@@ -624,13 +630,21 @@ const affectedRows = await userRepository.query<number>(
     'UPDATE "user" SET active = true WHERE id = $1',
     { args: ["123"], modifying: true },
 );
+
+// Only one row is ever expected here, so `singleResult` collapses the
+// array into a single object (or `null` when no row matches).
+const user = await userRepository.query<User | null>(
+    'SELECT * FROM "user" WHERE id = $1 LIMIT 1',
+    { args: ["123"], singleResult: true },
+);
 ```
 
-| Option      | Type      | Default                     | Description                                                                                                              |
-| ----------- | --------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `args`      | `any[]`   | `undefined`                 | Positional parameters injected into `$1`, `$2`, ... placeholders. Never interpolate values directly into the SQL string. |
-| `db`        | `any`     | Repository's default client | Database client or transaction to run this query in.                                                                     |
-| `modifying` | `boolean` | `false`                     | When `true`, treats the statement as `INSERT`/`UPDATE`/`DELETE`.                                                         |
+| Option         | Type      | Default                     | Description                                                                                                                                                        |
+| -------------- | --------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `args`         | `any[]`   | `undefined`                  | Positional parameters injected into `$1`, `$2`, ... placeholders. Never interpolate values directly into the SQL string.                                          |
+| `db`           | `any`     | Repository's default client  | Database client or transaction to run this query in.                                                                                                              |
+| `modifying`    | `boolean` | `false`                      | When `true`, treats the statement as `INSERT`/`UPDATE`/`DELETE`.                                                                                                   |
+| `singleResult` | `boolean` | `false`                      | When `true`, collapses an array result into its first element (`null` if empty). Has no effect on non-array results (e.g. a `modifying` query's affected-row count). |
 
 Just like base, dynamic and query methods, `query()` accepts `db` in `options` to participate in a `transaction()` block.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ VSRepository lets you create strongly-typed repositories with:
     - [Ordering, pagination and distinct](#ordering-pagination-and-distinct)
     - [Decorator options](#decorator-options)
 - [Query methods (raw SQL)](#query-methods-raw-sql)
+    - [Spread arguments with `spreadArgs`](#spread-arguments-with-spreadargs)
     - [Ad-hoc raw queries with `query()`](#ad-hoc-raw-queries-with-query)
 - [Transactions](#transactions)
 - [Utility types](#utility-types)
@@ -613,6 +614,33 @@ class UserRepository extends VSRepository<User, string> {
 
 Query methods accept `{ args, db? }` at the call site — `db` lets them participate in a `transaction()` block just like base and dynamic methods.
 
+### Spread arguments with `spreadArgs`
+
+By default, a `@QueryMethod` receives its placeholder values through a single `QueryMethodArg` object (`method({ args: [...] })`). Set `spreadArgs: true` to receive them as separate positional arguments instead, JpaRepository style:
+
+```typescript
+class UserRepository extends VSRepository<User, string> {
+    @QueryMethod('SELECT * FROM "user" WHERE email = $1 AND "userType" = $2', {
+        spreadArgs: true,
+    })
+    declare findByEmailAndType: (
+        ...args: QueryArgs<[email: string, userType: string]>
+    ) => Promise<User[]>;
+}
+
+const admins = await userRepository.findByEmailAndType("joao@email.com", "admin");
+```
+
+To run the query against a specific client or transaction instead of the repository's default one, pass `withDb(tx)` as the trailing argument — it wraps `tx` in a `DbArg`, which the resolver recognizes with `instanceof`, so it's never confused with a regular positional argument even if that argument happens to be an object:
+
+```typescript
+await userRepository.transaction(async (tx) => {
+    await userRepository.findByEmailAndType("joao@email.com", "admin", withDb(tx));
+});
+```
+
+`spreadArgs` only affects `@QueryMethod`-declared fields — it's `false` by default, and calling a method declared without it using more than one argument throws, since the single-`QueryMethodArg` call style is expected instead. It has no effect on `query()`, which always accepts `{ args, db? }`.
+
 ### Ad-hoc raw queries with `query()`
 
 For one-off raw SQL that doesn't warrant declaring a `@QueryMethod` on the repository class, call `query()` directly — it's available on every `VSRepository` instance and goes through the same adapter's `query()` implementation under the hood:
@@ -705,6 +733,7 @@ import type {
     DeepPartial,
     CountResult,
     QueryMethodArg,
+    QueryArgs,
     KeysOfType,
     NumericKeys,
     NumericLike,
@@ -727,6 +756,7 @@ import type {
 | `DeepPartial<T>`                                    | Recursively makes every property of `T` optional, including nested objects and array elements.                                                                                                       | `save`, `saveList`, `patch`, `merge`, and every write method on `VSRepoAdapter`.                                                                              |
 | `CountResult`                                       | `{ count: number }` — the shape returned by batch operations.                                                                                                                                        | `removeList`, `softRemoveList`, `restoreList`, `createManyIgnoreConflicts`.                                                                                   |
 | `QueryMethodArg<T>`                                 | `{ args?: T, db? }` — positional SQL parameters (`$1`, `$2`, ...) and transaction client for `@QueryMethod`.                                                                                         | [Query methods (raw SQL)](#query-methods-raw-sql).                                                                                                            |
+| `QueryArgs<T, O>`                                   | Types the spread parameter list of a `@QueryMethod` declared with `{ spreadArgs: true }`: `T`'s values in order, followed by an optional trailing `DbArg<O>` built via `withDb()`.                  | [Spread arguments with `spreadArgs`](#spread-arguments-with-spreadargs).                                                                                      |
 | `KeysOfType<T, K>`                                  | Extracts the keys of `T` whose value type is assignable to `K`.                                                                                                                                      | Constrains `pkName` in [Constructor options](#constructor-options) to fields of the entity matching the configured primary-key type.                          |
 | `NumericKeys<T>`                                    | Extracts the keys of `T` whose (non-nullable) value type is assignable to `NumericLike`. Nullable numeric fields (`number \| null`) are included.                                                   | Constrains `field` in [Atomic and aggregate methods](#atomic-and-aggregate-methods) (`increment`, `sum`, etc).                                                |
 | `NumericLike`                                       | `number \| bigint \| DecimalLike`.                                                                                                                                                                    | [Atomic and aggregate methods](#atomic-and-aggregate-methods).                                                                                                 |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -51,6 +51,7 @@ O VSRepository permite criar repositories fortemente tipados com:
     - [Ordenação, paginação e distinct](#ordenação-paginação-e-distinct)
     - [Options do decorador](#options-do-decorador)
 - [Query methods (SQL raw)](#query-methods-sql-raw)
+    - [Argumentos via spread com `spreadArgs`](#argumentos-via-spread-com-spreadargs)
     - [Queries raw pontuais com `query()`](#queries-raw-pontuais-com-query)
 - [Transações](#transações)
 - [Tipos utilitários](#tipos-utilitários)
@@ -613,6 +614,33 @@ class UserRepository extends VSRepository<User, string> {
 
 Query methods aceitam `{ args, db? }` na chamada — `db` permite que participem de um bloco `transaction()`, assim como os métodos base e dinâmicos.
 
+### Argumentos via spread com `spreadArgs`
+
+Por padrão, um `@QueryMethod` recebe seus valores de placeholder através de um único objeto `QueryMethodArg` (`method({ args: [...] })`). Defina `spreadArgs: true` para recebê-los como argumentos posicionais separados, no estilo do JpaRepository:
+
+```typescript
+class UserRepository extends VSRepository<User, string> {
+    @QueryMethod('SELECT * FROM "user" WHERE email = $1 AND "userType" = $2', {
+        spreadArgs: true,
+    })
+    declare findByEmailAndType: (
+        ...args: QueryArgs<[email: string, userType: string]>
+    ) => Promise<User[]>;
+}
+
+const admins = await userRepository.findByEmailAndType("joao@email.com", "admin");
+```
+
+Para rodar a query com um client ou transação específico em vez do client padrão do repository, passe `withDb(tx)` como argumento final — ele embrulha `tx` em um `DbArg`, que o resolver reconhece via `instanceof`, então nunca é confundido com um argumento posicional comum, mesmo que esse argumento seja um objeto:
+
+```typescript
+await userRepository.transaction(async (tx) => {
+    await userRepository.findByEmailAndType("joao@email.com", "admin", withDb(tx));
+});
+```
+
+`spreadArgs` afeta apenas campos declarados com `@QueryMethod` — o padrão é `false`, e chamar um método declarado sem essa opção usando mais de um argumento lança erro, já que se espera o estilo de chamada com um único `QueryMethodArg`. Não tem efeito sobre `query()`, que sempre aceita `{ args, db? }`.
+
 ### Queries raw pontuais com `query()`
 
 Para SQL raw pontual que não justifica declarar um `@QueryMethod` na classe do repository, chame `query()` diretamente — ele está disponível em toda instância de `VSRepository` e passa pela mesma implementação de `query()` do adapter por baixo dos panos:
@@ -708,6 +736,7 @@ import type {
     DeepPartial,
     CountResult,
     QueryMethodArg,
+    QueryArgs,
     KeysOfType,
     NumericKeys,
     NumericLike,
@@ -730,6 +759,7 @@ import type {
 | `DeepPartial<T>`                                    | Torna todas as propriedades de `T` opcionais recursivamente, incluindo objetos aninhados e elementos de array.                                                                                                      | `save`, `saveList`, `patch`, `merge`, e todo método de escrita do `VSRepoAdapter`.                                                                                  |
 | `CountResult`                                       | `{ count: number }` — o formato retornado por operações em lote.                                                                                                                                                    | `removeList`, `softRemoveList`, `restoreList`, `createManyIgnoreConflicts`.                                                                                         |
 | `QueryMethodArg<T>`                                 | `{ args?: T, db? }` — parâmetros posicionais do SQL (`$1`, `$2`, ...) e cliente de transação para o `@QueryMethod`.                                                                                                 | [Query methods (SQL raw)](#query-methods-sql-raw).                                                                                                                  |
+| `QueryArgs<T, O>`                                   | Tipa a lista de parâmetros via spread de um `@QueryMethod` declarado com `{ spreadArgs: true }`: os valores de `T`, em ordem, seguidos de um `DbArg<O>` opcional construído via `withDb()`.                       | [Argumentos via spread com `spreadArgs`](#argumentos-via-spread-com-spreadargs).                                                                                    |
 | `KeysOfType<T, K>`                                  | Extrai as chaves de `T` cujo tipo de valor é atribuível a `K`.                                                                                                                                                      | Restringe `pkName`, em [Options do construtor](#options-do-construtor), aos campos da entidade compatíveis com o tipo de chave primária configurado.                |
 | `NumericKeys<T>`                                    | Extrai as chaves de `T` cujo tipo de valor (ignorando `null`/`undefined`) é atribuível a `NumericLike`. Campos numéricos nullable (`number \| null`) são incluídos.                                                | Restringe `field` em [Métodos atômicos e de agregação](#métodos-atômicos-e-de-agregação) (`increment`, `sum`, etc).                                                 |
 | `NumericLike`                                       | `number \| bigint \| DecimalLike`.                                                                                                                                                                                   | [Métodos atômicos e de agregação](#métodos-atômicos-e-de-agregação).                                                                                                 |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -979,7 +979,7 @@ try {
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `DECORATOR`       | Argumentos inválidos foram passados para `@DynamicMethod` ou `@QueryMethod`.                                                               |
 | `RESOLVER`        | A biblioteca falhou ao resolver a configuração de um método dinâmico/de query em um método chamável (ex.: um nome de método desconhecido). |
-| `DYNAMIC`         | Um método dinâmico já resolvido falhou em tempo de execução (ex.: argumentos faltando).                                                    |
+| `DYNAMIC`         | Um dynamic/query method já resolvido falhou em tempo de execução (ex.: argumentos faltando).                                                    |
 | `VALIDATOR`       | Options ou argumentos de método inválidos foram detectados durante a validação.                                                            |
 | `BASE`            | Uso inválido de um método base (`get`, `save`, `remove`, etc).                                                                             |
 | `ADAPTER`         | Um `VSRepoAdapter` falhou ao falar com o ORM/banco subjacente — sempre é lançado como `VSRepoAdapterError`.                                |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -598,12 +598,18 @@ class UserRepository extends VSRepository<User, string> {
 
     @QueryMethod('UPDATE "user" SET active = true WHERE id = $1', { modifying: true })
     declare activateUser: (arg: QueryMethodArg<[id: string]>) => Promise<number>;
+
+    // Aqui só se espera uma linha, então `singleResult` transforma o array
+    // em um único objeto (ou `null` quando nenhuma linha corresponde).
+    @QueryMethod('SELECT * FROM "user" WHERE id = $1 LIMIT 1', { singleResult: true })
+    declare findByIdRaw: (arg: QueryMethodArg<[id: string]>) => Promise<User | null>;
 }
 ```
 
-| Option      | Tipo      | Padrão  | Descrição                                                                                                                                                                                             |
-| ----------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `modifying` | `boolean` | `false` | Quando `true`, executa como `INSERT`/`UPDATE`/`DELETE` e o método resolve para o número de linhas afetadas. Quando `false`, executa como query de leitura e resolve para o tipo de retorno declarado. |
+| Option         | Tipo      | Padrão  | Descrição                                                                                                                                                                                             |
+| -------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `modifying`    | `boolean` | `false` | Quando `true`, executa como `INSERT`/`UPDATE`/`DELETE` e o método resolve para o número de linhas afetadas. Quando `false`, executa como query de leitura e resolve para o tipo de retorno declarado. |
+| `singleResult` | `boolean` | `false` | Quando `true`, transforma um resultado em array no seu primeiro elemento (`null` se vazio), permitindo declarar o tipo de retorno como um objeto único em vez de array. Não tem efeito em resultados que não são array (ex.: o número de linhas afetadas de uma query `modifying`). |
 
 Query methods aceitam `{ args, db? }` na chamada — `db` permite que participem de um bloco `transaction()`, assim como os métodos base e dinâmicos.
 
@@ -612,7 +618,7 @@ Query methods aceitam `{ args, db? }` na chamada — `db` permite que participem
 Para SQL raw pontual que não justifica declarar um `@QueryMethod` na classe do repository, chame `query()` diretamente — ele está disponível em toda instância de `VSRepository` e passa pela mesma implementação de `query()` do adapter por baixo dos panos:
 
 ```typescript
-query<T = any>(query: string, options?: { args?: any[]; db?: any; modifying?: boolean }): Promise<T>;
+query<T = any>(query: string, options?: { args?: any[]; db?: any; modifying?: boolean; singleResult?: boolean }): Promise<T>;
 ```
 
 ```typescript
@@ -624,13 +630,21 @@ const linhasAfetadas = await userRepository.query<number>(
     'UPDATE "user" SET active = true WHERE id = $1',
     { args: ["123"], modifying: true },
 );
+
+// Aqui só se espera uma linha, então `singleResult` transforma o array
+// em um único objeto (ou `null` quando nenhuma linha corresponde).
+const user = await userRepository.query<User | null>(
+    'SELECT * FROM "user" WHERE id = $1 LIMIT 1',
+    { args: ["123"], singleResult: true },
+);
 ```
 
-| Option      | Tipo      | Padrão                      | Descrição                                                                                                            |
-| ----------- | --------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `args`      | `any[]`   | `undefined`                 | Parâmetros posicionais injetados nos placeholders `$1`, `$2`, ... Nunca interpole valores diretamente na string SQL. |
-| `db`        | `any`     | Client padrão do repository | Client ou transação do banco em que essa query deve rodar.                                                           |
-| `modifying` | `boolean` | `false`                     | Quando `true`, trata a instrução como `INSERT`/`UPDATE`/`DELETE`.                                                    |
+| Option         | Tipo      | Padrão                      | Descrição                                                                                                                                             |
+| -------------- | --------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `args`         | `any[]`   | `undefined`                  | Parâmetros posicionais injetados nos placeholders `$1`, `$2`, ... Nunca interpole valores diretamente na string SQL.                                  |
+| `db`           | `any`     | Client padrão do repository  | Client ou transação do banco em que essa query deve rodar.                                                                                             |
+| `modifying`    | `boolean` | `false`                      | Quando `true`, trata a instrução como `INSERT`/`UPDATE`/`DELETE`.                                                                                      |
+| `singleResult` | `boolean` | `false`                      | Quando `true`, transforma um resultado em array no seu primeiro elemento (`null` se vazio). Não tem efeito em resultados que não são array (ex.: o número de linhas afetadas de uma query `modifying`). |
 
 Assim como os métodos base, dinâmicos e query, `query()` aceita `db` em `options` para participar de um bloco `transaction()`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsrepo",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "ORM-agnostic repository pattern library with full TypeScript support and automatic type inference.",
   "homepage": "https://github.com/jaobrabo123/VSRepository#readme",
   "repository": {

--- a/src/VSRepository.ts
+++ b/src/VSRepository.ts
@@ -241,9 +241,12 @@ export abstract class VSRepository<
                 modifying: optionsValidated.modifying ?? false,
             });
 
+            const resolved =
+                optionsValidated.singleResult && Array.isArray(result) ? result[0] : result;
+
             this.logger.endPerformLog(start);
 
-            return result;
+            return resolved;
         } catch (err) {
             this.logger.endPerformLog(start);
             // this.logger.logError(`Failed to run 'query' on ${this.constructor.name}`, err);

--- a/src/VSRepository.ts
+++ b/src/VSRepository.ts
@@ -210,6 +210,8 @@ export abstract class VSRepository<
      * Use `$1`, `$2`, ... placeholders for values passed via `options.args` —
      * never interpolate values directly into `query`, to avoid SQL injection.
      * Set `options.modifying: true` for `INSERT`/`UPDATE`/`DELETE` statements.
+     * Set `options.singleResult: true` to collapse an array result into its
+     * first element (`null` if empty) — see {@link VSRepoQueryOptions.singleResult}.
      *
      * @example
      * ```typescript
@@ -221,6 +223,13 @@ export abstract class VSRepository<
      * const affected = await userRepository.query<number>(
      *     'UPDATE "user" SET active = true WHERE id = $1',
      *     { args: ["123"], modifying: true },
+     * );
+     *
+     * // Only one row is ever expected here, so `singleResult` collapses the
+     * // array into a single object (or `null` when no row matches).
+     * const user = await userRepository.query<User | null>(
+     *     'SELECT * FROM "user" WHERE id = $1 LIMIT 1',
+     *     { args: ["123"], singleResult: true },
      * );
      * ```
      */
@@ -242,7 +251,9 @@ export abstract class VSRepository<
             });
 
             const resolved =
-                optionsValidated.singleResult && Array.isArray(result) ? result[0] : result;
+                optionsValidated.singleResult && Array.isArray(result)
+                    ? (result[0] ?? null)
+                    : result;
 
             this.logger.endPerformLog(start);
 

--- a/src/decorators/query-method.decorator.ts
+++ b/src/decorators/query-method.decorator.ts
@@ -15,7 +15,9 @@ import { VSRepoQuery } from "../types/vsrepo/vsrepo-query.type";
  *
  * @param value Raw SQL statement to execute. Use `$1`, `$2`, ... placeholders for
  * the values that will be passed via `args` — never interpolate values directly into `value`.
- * @param options Optional configuration; set `modifying: true` for `INSERT`/`UPDATE`/`DELETE` statements.
+ * @param options Optional configuration; set `modifying: true` for `INSERT`/`UPDATE`/`DELETE` statements,
+ * and `singleResult: true` to collapse an array result into its first element — see
+ * {@link QueryMethodOptions.singleResult}.
  *
  * @example
  * ```typescript
@@ -25,6 +27,11 @@ import { VSRepoQuery } from "../types/vsrepo/vsrepo-query.type";
  *
  *     @QueryMethod('UPDATE "user" SET active = true WHERE id = $1', { modifying: true })
  *     declare activateUser: (arg: QueryMethodArg<[id: string]>) => Promise<number>;
+ *
+ *     // Only one row is ever expected here, so `singleResult` collapses the
+ *     // array into a single object (or `null` when no row matches).
+ *     @QueryMethod('SELECT * FROM "user" WHERE id = $1 LIMIT 1', { singleResult: true })
+ *     declare findByIdRaw: (arg: QueryMethodArg<[id: string]>) => Promise<User | null>;
  * }
  * ```
  *

--- a/src/decorators/query-method.decorator.ts
+++ b/src/decorators/query-method.decorator.ts
@@ -11,13 +11,16 @@ import { VSRepoQuery } from "../types/vsrepo/vsrepo-query.type";
  *
  * Applied to a `declare` class field, it executes `value` directly through the
  * adapter's `query()` method, with parameters injected positionally via the
- * `args` array passed at the call site (`$1`, `$2`, ... placeholders).
+ * `args` array passed at the call site (`$1`, `$2`, ... placeholders) — or,
+ * with `spreadArgs: true`, via separate positional arguments instead.
  *
  * @param value Raw SQL statement to execute. Use `$1`, `$2`, ... placeholders for
  * the values that will be passed via `args` — never interpolate values directly into `value`.
  * @param options Optional configuration; set `modifying: true` for `INSERT`/`UPDATE`/`DELETE` statements,
- * and `singleResult: true` to collapse an array result into its first element — see
- * {@link QueryMethodOptions.singleResult}.
+ * `singleResult: true` to collapse an array result into its first element, and
+ * `spreadArgs: true` to receive placeholder values as separate arguments instead of a
+ * single `QueryMethodArg` object — see {@link QueryMethodOptions.singleResult} and
+ * {@link QueryMethodOptions.spreadArgs}.
  *
  * @example
  * ```typescript
@@ -32,7 +35,20 @@ import { VSRepoQuery } from "../types/vsrepo/vsrepo-query.type";
  *     // array into a single object (or `null` when no row matches).
  *     @QueryMethod('SELECT * FROM "user" WHERE id = $1 LIMIT 1', { singleResult: true })
  *     declare findByIdRaw: (arg: QueryMethodArg<[id: string]>) => Promise<User | null>;
+ *
+ *     // `spreadArgs: true` takes placeholder values as separate arguments,
+ *     // JpaRepository style, instead of a single `{ args: [...] }` object.
+ *     // An optional trailing `withDb(tx)` runs the query in a transaction.
+ *     @QueryMethod('SELECT * FROM "user" WHERE email = $1 AND "userType" = $2', {
+ *         spreadArgs: true,
+ *     })
+ *     declare findByEmailAndType: (
+ *         ...args: QueryArgs<[email: string, userType: string]>
+ *     ) => Promise<User[]>;
  * }
+ *
+ * await userRepository.findByEmailAndType("joao@email.com", "admin");
+ * await userRepository.findByEmailAndType("joao@email.com", "admin", withDb(tx));
  * ```
  *
  * @publicApi

--- a/src/decorators/query-method.decorator.ts
+++ b/src/decorators/query-method.decorator.ts
@@ -2,7 +2,7 @@ import { VSRepoError } from "../errors/VSRepoError";
 import { QUERY_METHODS_KEY } from "../internal/constants/query-methods-key.constant";
 import { VSRepoErrorType } from "../internal/enums/vsrepo-error-type.enum";
 import { DecoratorsValidator } from "../internal/validators/decorators.validator";
-import { QueryMethodOptions } from "../types/decorators/query-method-options.type";
+import type { QueryMethodOptions } from "../types/decorators/query-method-options.type";
 import { VSRepoQuery } from "../types/vsrepo/vsrepo-query.type";
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ export { VSRepoAdapterError } from "./errors/VSRepoAdapterError.js";
 export { DbArg } from "./internal/utils/db-arg.util.js";
 
 // Decorators
-export { DynamicMethod, DynamicMethod as Dynamic } from "./decorators/dynamic-method.decorator.js";
-export { QueryMethod, QueryMethod as Query } from "./decorators/query-method.decorator.js";
+export { DynamicMethod } from "./decorators/dynamic-method.decorator.js";
+export { QueryMethod } from "./decorators/query-method.decorator.js";
 
 // Public enums
 export { VSRepoErrorType } from "./internal/enums/vsrepo-error-type.enum.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { VSRepository } from "./VSRepository.js";
 export { VSRepoAdapter } from "./VSRepoAdapter.js";
 export { VSRepoError } from "./errors/VSRepoError.js";
 export { VSRepoAdapterError } from "./errors/VSRepoAdapterError.js";
+export { DbArg } from "./internal/utils/db-arg.util.js";
 
 // Decorators
 export { DynamicMethod } from "./decorators/dynamic-method.decorator.js";
@@ -15,6 +16,9 @@ export { VSRepoErrorType } from "./internal/enums/vsrepo-error-type.enum.js";
 export { VSLogLevel } from "./internal/enums/vs-log-level.enum.js";
 export { TransactionIsolationLevel } from "./internal/enums/transaction-isolation-level.enum.js";
 export { AdapterErrorCode } from "./internal/enums/adapter-error-code.enum.js";
+
+// Public functions
+export { withDb } from "./internal/utils/with-db.util.js";
 
 // Public types
 export type { VSRepoOptions } from "./types/vsrepo/vsrepo-options.type.js";
@@ -48,6 +52,7 @@ export type { DecimalLike } from "./types/utils/decimal-like.type.js";
 export type { NumericKeys } from "./types/utils/numeric-keys.type.js";
 export type { NumericLike } from "./types/utils/numeric-like.type.js";
 export type { RestrictMethodOptions } from "./types/utils/restrict-method-options.type.js";
+export type { QueryArgs } from "./types/utils/query-args.type.js";
 
 // Internal features
 export { VSLogger } from "./internal/utils/vs-logger.util.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ export { VSRepoAdapterError } from "./errors/VSRepoAdapterError.js";
 export { DbArg } from "./internal/utils/db-arg.util.js";
 
 // Decorators
-export { DynamicMethod } from "./decorators/dynamic-method.decorator.js";
-export { QueryMethod } from "./decorators/query-method.decorator.js";
+export { DynamicMethod, DynamicMethod as Dynamic } from "./decorators/dynamic-method.decorator.js";
+export { QueryMethod, QueryMethod as Query } from "./decorators/query-method.decorator.js";
 
 // Public enums
 export { VSRepoErrorType } from "./internal/enums/vsrepo-error-type.enum.js";

--- a/src/internal/enums/vsrepo-error-type.enum.ts
+++ b/src/internal/enums/vsrepo-error-type.enum.ts
@@ -8,7 +8,7 @@ export enum VSRepoErrorType {
     DECORATOR = "DECORATOR",
     /** Failure while resolving a dynamic or query method's configuration into a callable method. */
     RESOLVER = "RESOLVER",
-    /** Failure while executing a resolved dynamic method at runtime. */
+    /** Failure while executing a resolved dynamic/query method at runtime. */
     DYNAMIC = "DYNAMIC",
     /** Invalid method options or arguments detected during validation. */
     VALIDATOR = "VALIDATOR",

--- a/src/internal/resolvers/dynamic-methods.resolver.ts
+++ b/src/internal/resolvers/dynamic-methods.resolver.ts
@@ -1002,6 +1002,7 @@ export class DynamicMethodsResolver<T, K> {
 
             const modifyingQueryMethod = method.modifying;
             const valueQueryMethod = method.value;
+            const singleResult = method.singleResult;
 
             (instance as any)[originalKey] = async (arg: unknown) => {
                 const queryArgValidated = this.validator.validateQueryMethodArg(arg);
@@ -1017,9 +1018,11 @@ export class DynamicMethodsResolver<T, K> {
                         modifying: modifyingQueryMethod,
                     });
 
+                    const resolved = singleResult && Array.isArray(result) ? result[0] : result;
+
                     this.logger.endPerformLog(start);
 
-                    return result;
+                    return resolved;
                 } catch (err) {
                     this.logger.endPerformLog(start);
                     // this.logger.logError(

--- a/src/internal/resolvers/dynamic-methods.resolver.ts
+++ b/src/internal/resolvers/dynamic-methods.resolver.ts
@@ -1013,7 +1013,7 @@ export class DynamicMethodsResolver<T, K> {
                 if (spreadArgsMode) {
                     const dbPos = args.at(-1);
                     if (dbPos instanceof DbArg) {
-                        db = dbPos;
+                        db = dbPos.getDb();
                         queryArgs = args.slice(0, -1);
                     } else {
                         queryArgs = args;

--- a/src/internal/resolvers/dynamic-methods.resolver.ts
+++ b/src/internal/resolvers/dynamic-methods.resolver.ts
@@ -1000,7 +1000,7 @@ export class DynamicMethodsResolver<T, K> {
         for (const method of queryMethods) {
             const originalKey = method.propertyKey;
 
-            const modifyingQueryMethod = method.modifying;
+            const modifyingQueryMethod = method.modifying ?? false;
             const valueQueryMethod = method.value;
             const singleResult = method.singleResult;
 
@@ -1018,7 +1018,8 @@ export class DynamicMethodsResolver<T, K> {
                         modifying: modifyingQueryMethod,
                     });
 
-                    const resolved = singleResult && Array.isArray(result) ? result[0] : result;
+                    const resolved =
+                        singleResult && Array.isArray(result) ? (result[0] ?? null) : result;
 
                     this.logger.endPerformLog(start);
 

--- a/src/internal/resolvers/dynamic-methods.resolver.ts
+++ b/src/internal/resolvers/dynamic-methods.resolver.ts
@@ -23,6 +23,7 @@ import { MergeWheresResolver } from "./merge-wheres.resolver";
 import merge from "deepmerge";
 import { VSRepoErrorType } from "../enums/vsrepo-error-type.enum";
 import { DEBUG_ARG_SYMBOL } from "../constants/debug-arg-symbol.constant";
+import { DbArg } from "../utils/db-arg.util";
 
 export class DynamicMethodsResolver<T, K> {
     constructor(
@@ -1003,10 +1004,35 @@ export class DynamicMethodsResolver<T, K> {
             const modifyingQueryMethod = method.modifying ?? false;
             const valueQueryMethod = method.value;
             const singleResult = method.singleResult;
+            const spreadArgsMode = method.spreadArgs;
 
-            (instance as any)[originalKey] = async (arg: unknown) => {
-                const queryArgValidated = this.validator.validateQueryMethodArg(arg);
-                queryArgValidated.db ??= this.adapter.getDbClient();
+            (instance as any)[originalKey] = async (...args: unknown[]) => {
+                let db: any;
+                let queryArgs: any[] | undefined;
+
+                if (spreadArgsMode) {
+                    const dbPos = args.at(-1);
+                    if (dbPos instanceof DbArg) {
+                        db = dbPos;
+                        queryArgs = args.slice(0, -1);
+                    } else {
+                        queryArgs = args;
+                    }
+                } else {
+                    if (args.length > 1) {
+                        const errorMessage = `This query method was declared without spreadArgs = true, use a single QueryMethodArg instead`;
+                        this.logger.logError(
+                            `Cannot run '${String(originalKey)}': ${errorMessage}`,
+                        );
+
+                        throw new VSRepoError(errorMessage, VSRepoErrorType.DYNAMIC);
+                    }
+                    const queryArgValidated = this.validator.validateQueryMethodArg(args[0]);
+                    db = queryArgValidated.db;
+                    queryArgs = queryArgValidated.args;
+                }
+
+                db ??= this.adapter.getDbClient();
 
                 const start = this.logger.startPerformLog(
                     `run ${String(originalKey)} (Modifying: ${modifyingQueryMethod})`,
@@ -1014,7 +1040,8 @@ export class DynamicMethodsResolver<T, K> {
 
                 try {
                     const result = await this.adapter.query(valueQueryMethod, {
-                        ...queryArgValidated,
+                        db,
+                        args: queryArgs,
                         modifying: modifyingQueryMethod,
                     });
 

--- a/src/internal/utils/db-arg.util.ts
+++ b/src/internal/utils/db-arg.util.ts
@@ -1,12 +1,18 @@
 import { VSRepoOrmTypes } from "../../types/vsrepo/vsrepo-orm-types.type";
 
 /**
+ * Wraps a database client or transaction so it can be recognized, at
+ * runtime, as the trailing `db` override in a {@link QueryArgs} spread call —
+ * as opposed to a regular positional query argument. Build one with
+ * {@link withDb} rather than constructing it directly.
+ *
  * @publicApi
  */
 export class DbArg<T extends VSRepoOrmTypes = VSRepoOrmTypes> {
-    constructor(private readonly db: T) {}
+    constructor(private readonly db: T["dbClient"] | T["dbTransaction"]) {}
 
-    getDb(): T {
+    /** Returns the wrapped database client or transaction. */
+    getDb(): T["dbClient"] | T["dbTransaction"] {
         return this.db;
     }
 }

--- a/src/internal/utils/db-arg.util.ts
+++ b/src/internal/utils/db-arg.util.ts
@@ -1,0 +1,12 @@
+import { VSRepoOrmTypes } from "../../types/vsrepo/vsrepo-orm-types.type";
+
+/**
+ * @publicApi
+ */
+export class DbArg<T extends VSRepoOrmTypes = VSRepoOrmTypes> {
+    constructor(private readonly db: T) {}
+
+    getDb(): T {
+        return this.db;
+    }
+}

--- a/src/internal/utils/with-db.util.ts
+++ b/src/internal/utils/with-db.util.ts
@@ -2,6 +2,19 @@ import { VSRepoOrmTypes } from "../../types/vsrepo/vsrepo-orm-types.type";
 import { DbArg } from "./db-arg.util";
 
 /**
+ * Wraps a database client or transaction so it can be passed as the
+ * trailing argument of a `@QueryMethod` declared with `{ spreadArgs: true }`,
+ * running that call against `db` instead of the repository's default
+ * client — the same role `{ db }` plays in the single-object
+ * `QueryMethodArg` call style.
+ *
+ * @example
+ * ```typescript
+ * await userRepository.transaction(async (tx) => {
+ *     await userRepository.findByEmailAndType("joao@email.com", "admin", withDb(tx));
+ * });
+ * ```
+ *
  * @publicApi
  */
 export function withDb<T extends VSRepoOrmTypes = VSRepoOrmTypes>(

--- a/src/internal/utils/with-db.util.ts
+++ b/src/internal/utils/with-db.util.ts
@@ -1,0 +1,11 @@
+import { VSRepoOrmTypes } from "../../types/vsrepo/vsrepo-orm-types.type";
+import { DbArg } from "./db-arg.util";
+
+/**
+ * @publicApi
+ */
+export function withDb<T extends VSRepoOrmTypes = VSRepoOrmTypes>(
+    db: T["dbClient"] | T["dbTransaction"],
+): DbArg<T> {
+    return new DbArg(db);
+}

--- a/src/internal/validators/decorators.validator.ts
+++ b/src/internal/validators/decorators.validator.ts
@@ -22,11 +22,12 @@ export class DecoratorsValidator {
             throw new VSRepoError(`${path}: ${firstIssue.message}`, VSRepoErrorType.DECORATOR);
         }
 
-        return parsed.output as DynamicMethodOptions;
+        return parsed.output;
     }
 
     private static queryMethodOptionsSchema = v.object({
         modifying: v.optional(v.boolean(), false),
+        singleResult: v.optional(v.boolean()),
     });
 
     static validateQueryMethodOptions(options: unknown): QueryMethodOptions {
@@ -40,6 +41,6 @@ export class DecoratorsValidator {
             throw new VSRepoError(`${path}: ${firstIssue.message}`, VSRepoErrorType.DECORATOR);
         }
 
-        return parsed.output as QueryMethodOptions;
+        return parsed.output;
     }
 }

--- a/src/internal/validators/decorators.validator.ts
+++ b/src/internal/validators/decorators.validator.ts
@@ -28,6 +28,7 @@ export class DecoratorsValidator {
     private static queryMethodOptionsSchema = v.object({
         modifying: v.optional(v.boolean(), false),
         singleResult: v.optional(v.boolean()),
+        spreadArgs: v.optional(v.boolean()),
     });
 
     static validateQueryMethodOptions(options: unknown): QueryMethodOptions {

--- a/src/internal/validators/vsrepo.validator.ts
+++ b/src/internal/validators/vsrepo.validator.ts
@@ -119,14 +119,14 @@ export class VSRepoValidator<T, K, O extends VSRepoOrmTypes = VSRepoOrmTypes> {
         db: v.optional(v.any()),
     });
 
-    validateQueryMethodArg(arg?: unknown): QueryMethodArg<any> {
+    validateQueryMethodArg(arg?: unknown): QueryMethodArg<any[]> {
         const parsed = v.safeParse(this.queryArgSchema, arg ?? {});
 
         if (!parsed.success) {
             this.failValidation(parsed.issues[0], VSRepoErrorType.VALIDATOR);
         }
 
-        return parsed.output as QueryMethodArg<any>;
+        return parsed.output;
     }
 
     private queryOptionsSchema = v.object({

--- a/src/internal/validators/vsrepo.validator.ts
+++ b/src/internal/validators/vsrepo.validator.ts
@@ -133,6 +133,7 @@ export class VSRepoValidator<T, K, O extends VSRepoOrmTypes = VSRepoOrmTypes> {
         args: v.optional(v.array(v.any())),
         db: v.optional(v.any()),
         modifying: v.optional(v.boolean()),
+        singleResult: v.optional(v.boolean()),
     });
 
     validateQueryOptions(options?: unknown): VSRepoQueryOptions {
@@ -142,7 +143,7 @@ export class VSRepoValidator<T, K, O extends VSRepoOrmTypes = VSRepoOrmTypes> {
             this.failValidation(parsed.issues[0], VSRepoErrorType.VALIDATOR);
         }
 
-        return parsed.output as VSRepoQueryOptions;
+        return parsed.output;
     }
 
     private transactionOptionsSchema = v.object({
@@ -157,7 +158,7 @@ export class VSRepoValidator<T, K, O extends VSRepoOrmTypes = VSRepoOrmTypes> {
             this.failValidation(parsed.issues[0], VSRepoErrorType.VALIDATOR);
         }
 
-        return parsed.output as VSRepoTransactionOptions;
+        return parsed.output;
     }
 
     validateOrdering(value: unknown): Ordering<T> {
@@ -177,7 +178,7 @@ export class VSRepoValidator<T, K, O extends VSRepoOrmTypes = VSRepoOrmTypes> {
             this.failValidation(parsed.issues[0], VSRepoErrorType.VALIDATOR, "pagination");
         }
 
-        return parsed.output as Pagination;
+        return parsed.output;
     }
 
     validateWhere(value: unknown): VSRepoWhere<T> {

--- a/src/types/decorators/query-method-options.type.ts
+++ b/src/types/decorators/query-method-options.type.ts
@@ -11,9 +11,19 @@ export type QueryMethodOptions = {
      * to whatever return type is declared on the field.
      * @default false
      */
-    modifying: boolean;
+    modifying?: boolean;
 
     /**
+     * When `true`, the array returned by the underlying query is collapsed
+     * into its first element (`null` if the array is empty) before
+     * being resolved to the caller. Has no effect when the query resolves
+     * to something other than an array (e.g. a `modifying` query's
+     * affected-row count).
+     *
+     * Useful for queries you already know return at most one row (e.g. a
+     * `SELECT ... LIMIT 1` or a lookup by a unique column), where declaring
+     * the return type as an array would be misleading.
+     *
      * @default false
      */
     singleResult?: boolean;

--- a/src/types/decorators/query-method-options.type.ts
+++ b/src/types/decorators/query-method-options.type.ts
@@ -12,4 +12,9 @@ export type QueryMethodOptions = {
      * @default false
      */
     modifying: boolean;
+
+    /**
+     * @default false
+     */
+    singleResult?: boolean;
 };

--- a/src/types/decorators/query-method-options.type.ts
+++ b/src/types/decorators/query-method-options.type.ts
@@ -28,5 +28,24 @@ export type QueryMethodOptions = {
      */
     singleResult?: boolean;
 
+    /**
+     * When `true`, the decorated method receives its SQL placeholder values
+     * as separate positional arguments (`method(a, b, c)`) instead of a
+     * single {@link QueryMethodArg} object (`method({ args: [a, b, c] })`).
+     * Type the declared field's parameters with {@link QueryArgs} to get
+     * autocompletion and arity checking for this call style.
+     *
+     * To run the query against a specific client or transaction — instead
+     * of the repository's default one — pass {@link DbArg} (built via
+     * {@link withDb}) as the trailing argument: `method(a, b, withDb(tx))`.
+     * It's recognized by `instanceof`, so it never collides with a regular
+     * positional argument, even one that happens to be an object.
+     *
+     * When `false` (the default), calling the method with more than one
+     * argument throws, since it expects the single-object `QueryMethodArg`
+     * call style instead.
+     *
+     * @default false
+     */
     spreadArgs?: boolean;
 };

--- a/src/types/decorators/query-method-options.type.ts
+++ b/src/types/decorators/query-method-options.type.ts
@@ -27,4 +27,6 @@ export type QueryMethodOptions = {
      * @default false
      */
     singleResult?: boolean;
+
+    spreadArgs?: boolean;
 };

--- a/src/types/utils/query-args.type.ts
+++ b/src/types/utils/query-args.type.ts
@@ -2,6 +2,27 @@ import { DbArg } from "../../internal/utils/db-arg.util";
 import { VSRepoOrmTypes } from "../vsrepo/vsrepo-orm-types.type";
 
 /**
+ * Types the parameter list of a `@QueryMethod` declared with
+ * `{ spreadArgs: true }`: the SQL placeholder values (`T`), in order,
+ * followed by an optional trailing {@link DbArg} — built via {@link withDb} —
+ * to run the query against a specific client or transaction instead of the
+ * repository's default one.
+ *
+ * @example
+ * ```typescript
+ * class UserRepository extends VSRepository<User, string> {
+ *     @QueryMethod('SELECT * FROM "user" WHERE email = $1 AND "userType" = $2', {
+ *         spreadArgs: true,
+ *     })
+ *     declare findByEmailAndType: (
+ *         ...args: QueryArgs<[email: string, userType: string]>
+ *     ) => Promise<User[]>;
+ * }
+ *
+ * await userRepository.findByEmailAndType("joao@email.com", "admin");
+ * await userRepository.findByEmailAndType("joao@email.com", "admin", withDb(tx));
+ * ```
+ *
  * @publicApi
  */
 export type QueryArgs<T extends Array<any> = [], O extends VSRepoOrmTypes = VSRepoOrmTypes> = [

--- a/src/types/utils/query-args.type.ts
+++ b/src/types/utils/query-args.type.ts
@@ -1,0 +1,10 @@
+import { DbArg } from "../../internal/utils/db-arg.util";
+import { VSRepoOrmTypes } from "../vsrepo/vsrepo-orm-types.type";
+
+/**
+ * @publicApi
+ */
+export type QueryArgs<T extends Array<any> = [], O extends VSRepoOrmTypes = VSRepoOrmTypes> = [
+    ...T,
+    db?: DbArg<O>,
+];

--- a/src/types/utils/query-method-arg.type.ts
+++ b/src/types/utils/query-method-arg.type.ts
@@ -1,3 +1,5 @@
+import { VSRepoOrmTypes } from "../vsrepo/vsrepo-orm-types.type";
+
 /**
  * Single argument accepted by a method declared with `@QueryMethod`.
  *
@@ -19,9 +21,9 @@
  *
  * @publicApi
  */
-export type QueryMethodArg<T extends Array<any>> = {
+export type QueryMethodArg<T extends Array<any> = [], O extends VSRepoOrmTypes = VSRepoOrmTypes> = {
     /** Positional parameters injected into the SQL placeholders (`$1`, `$2`, ...). */
     args?: T;
     /** Database client or transaction to run this query in, instead of the repository's default client. */
-    db?: any;
+    db?: O["dbClient"] | O["dbTransaction"];
 };

--- a/src/types/vsrepo/vsrepo-query-options.type.ts
+++ b/src/types/vsrepo/vsrepo-query-options.type.ts
@@ -15,4 +15,8 @@ export type VSRepoQueryOptions<T extends VSRepoOrmTypes = VSRepoOrmTypes> = {
      * @default false
      */
     modifying?: boolean;
+    /**
+     * @default false
+     */
+    singleResult?: boolean;
 };

--- a/src/types/vsrepo/vsrepo-query-options.type.ts
+++ b/src/types/vsrepo/vsrepo-query-options.type.ts
@@ -16,6 +16,16 @@ export type VSRepoQueryOptions<T extends VSRepoOrmTypes = VSRepoOrmTypes> = {
      */
     modifying?: boolean;
     /**
+     * When `true`, the array returned by the underlying query is collapsed
+     * into its first element (`null` if the array is empty) before
+     * being resolved to the caller. Has no effect when the query resolves
+     * to something other than an array (e.g. a `modifying` query's
+     * affected-row count).
+     *
+     * Useful for queries you already know return at most one row (e.g. a
+     * `SELECT ... LIMIT 1` or a lookup by a unique column), where declaring
+     * the return type as an array would be misleading.
+     *
      * @default false
      */
     singleResult?: boolean;

--- a/test/helpers/user-repository.ts
+++ b/test/helpers/user-repository.ts
@@ -8,6 +8,7 @@ import { VSRepoAdapter } from "../../src/VSRepoAdapter";
 import { DynamicMethod } from "../../src/decorators/dynamic-method.decorator";
 import { QueryMethod } from "../../src/decorators/query-method.decorator";
 import { QueryMethodArg } from "../../src/types/utils/query-method-arg.type";
+import { QueryArgs } from "../../src/types/utils/query-args.type";
 import { VSLogLevel } from "../../src/internal/enums/vs-log-level.enum";
 import { User } from "./entities";
 
@@ -45,6 +46,13 @@ export class UserRepository extends VSRepository<User, string> {
         singleResult: true,
     })
     declare activateUserRaw: (arg: QueryMethodArg<[id: string]>) => Promise<number>;
+
+    @QueryMethod('SELECT * FROM "user" WHERE email = $1 AND "userType" = $2', {
+        spreadArgs: true,
+    })
+    declare findByEmailAndTypeRaw: (
+        ...args: QueryArgs<[email: string, userType: string]>
+    ) => Promise<User[]>;
 }
 
 export class SoftDeletableUserRepository extends VSRepository<User, string> {

--- a/test/helpers/user-repository.ts
+++ b/test/helpers/user-repository.ts
@@ -36,6 +36,15 @@ export class UserRepository extends VSRepository<User, string> {
 
     @QueryMethod('SELECT * FROM "user" WHERE email = $1')
     declare findByEmailRaw: (arg: QueryMethodArg<[email: string]>) => Promise<User[]>;
+
+    @QueryMethod('SELECT * FROM "user" WHERE id = $1 LIMIT 1', { singleResult: true })
+    declare findByIdRaw: (arg: QueryMethodArg<[id: string]>) => Promise<User | null>;
+
+    @QueryMethod('UPDATE "user" SET active = true WHERE id = $1', {
+        modifying: true,
+        singleResult: true,
+    })
+    declare activateUserRaw: (arg: QueryMethodArg<[id: string]>) => Promise<number>;
 }
 
 export class SoftDeletableUserRepository extends VSRepository<User, string> {

--- a/test/implementation/base-methods.test.ts
+++ b/test/implementation/base-methods.test.ts
@@ -221,4 +221,52 @@ describe("transaction / getDbClient / query", () => {
     it("'query' rejeita quando 'query' não é uma string", async () => {
         await expect(userRepository.query(123 as any)).rejects.toThrow();
     });
+
+    describe("'singleResult'", () => {
+        it("com 'singleResult: true' e resultado em array, resolve para o primeiro elemento", async () => {
+            const user = buildUser();
+            fakeAdapter.query.mockResolvedValueOnce([user]);
+
+            const result = await userRepository.query('SELECT * FROM "user" WHERE id = $1 LIMIT 1', {
+                args: ["user-1"],
+                singleResult: true,
+            });
+
+            expect(result).toBe(user);
+        });
+
+        it("com 'singleResult: true' e array vazio, resolve para 'null'", async () => {
+            fakeAdapter.query.mockResolvedValueOnce([]);
+
+            const result = await userRepository.query('SELECT * FROM "user" WHERE id = $1 LIMIT 1', {
+                args: ["missing"],
+                singleResult: true,
+            });
+
+            expect(result).toBeNull();
+        });
+
+        it("com 'singleResult: true' e resultado que não é array (ex.: query 'modifying'), mantém o valor original", async () => {
+            fakeAdapter.query.mockResolvedValueOnce(1);
+
+            const result = await userRepository.query('UPDATE "user" SET active = true WHERE id = $1', {
+                args: ["user-1"],
+                modifying: true,
+                singleResult: true,
+            });
+
+            expect(result).toBe(1);
+        });
+
+        it("sem 'singleResult' (padrão 'false'), mantém o array como está", async () => {
+            const users = [buildUser(), buildUser()];
+            fakeAdapter.query.mockResolvedValueOnce(users);
+
+            const result = await userRepository.query('SELECT * FROM "user" WHERE email = $1', {
+                args: ["joao@email.com"],
+            });
+
+            expect(result).toBe(users);
+        });
+    });
 });

--- a/test/implementation/dynamic-methods.test.ts
+++ b/test/implementation/dynamic-methods.test.ts
@@ -10,6 +10,8 @@ import { VSRepoAdapter } from "../../src/VSRepoAdapter";
 import { createFakeAdapter } from "../helpers/fake-adapter";
 import { UserRepository } from "../helpers/user-repository";
 import { User, buildUser } from "../helpers/entities";
+import { withDb } from "../../src/internal/utils/with-db.util";
+import { VSRepoError } from "../../src/errors/VSRepoError";
 
 let fakeAdapter: jest.Mocked<VSRepoAdapter<User>>;
 let userRepository: UserRepository;
@@ -125,6 +127,48 @@ describe("@QueryMethod — query crua", () => {
                 expect.objectContaining({ args: ["user-1"], modifying: true }),
             );
             expect(result).toBe(1);
+        });
+    });
+
+    describe("'spreadArgs'", () => {
+        it("'findByEmailAndTypeRaw' recebe os placeholders como argumentos posicionais e usa o client padrão como 'db'", async () => {
+            const users = [buildUser()];
+            fakeAdapter.query.mockResolvedValueOnce(users);
+
+            const result = await userRepository.findByEmailAndTypeRaw("joao@email.com", "admin");
+
+            expect(fakeAdapter.query).toHaveBeenCalledWith(
+                'SELECT * FROM "user" WHERE email = $1 AND "userType" = $2',
+                expect.objectContaining({ args: ["joao@email.com", "admin"], modifying: false }),
+            );
+            expect(result).toBe(users);
+        });
+
+        it("um 'withDb(tx)' à direita é extraído dos 'args' e repassado como 'db' — desembrulhado, não a instância de 'DbArg'", async () => {
+            const users = [buildUser()];
+            fakeAdapter.query.mockResolvedValueOnce(users);
+            const fakeTx = { isFakeTx: true };
+
+            await userRepository.findByEmailAndTypeRaw(
+                "joao@email.com",
+                "admin",
+                withDb(fakeTx),
+            );
+
+            expect(fakeAdapter.query).toHaveBeenCalledWith(
+                'SELECT * FROM "user" WHERE email = $1 AND "userType" = $2',
+                expect.objectContaining({
+                    args: ["joao@email.com", "admin"],
+                    db: fakeTx,
+                    modifying: false,
+                }),
+            );
+        });
+
+        it("chamar um método declarado sem 'spreadArgs' com mais de um argumento lança 'VSRepoError'", async () => {
+            await expect(
+                (userRepository.findByEmailRaw as any)("joao@email.com", "extra"),
+            ).rejects.toThrow(VSRepoError);
         });
     });
 });

--- a/test/implementation/dynamic-methods.test.ts
+++ b/test/implementation/dynamic-methods.test.ts
@@ -92,4 +92,39 @@ describe("@QueryMethod — query crua", () => {
         );
         expect(result).toBe(users);
     });
+
+    describe("'singleResult'", () => {
+        it("'findByIdRaw' (singleResult: true) resolve para o primeiro elemento do array retornado pelo adapter", async () => {
+            const user = buildUser();
+            fakeAdapter.query.mockResolvedValueOnce([user]);
+
+            const result = await userRepository.findByIdRaw({ args: ["user-1"] });
+
+            expect(fakeAdapter.query).toHaveBeenCalledWith(
+                'SELECT * FROM "user" WHERE id = $1 LIMIT 1',
+                expect.objectContaining({ args: ["user-1"], modifying: false }),
+            );
+            expect(result).toBe(user);
+        });
+
+        it("'findByIdRaw' (singleResult: true) resolve para 'null' quando o adapter retorna um array vazio", async () => {
+            fakeAdapter.query.mockResolvedValueOnce([]);
+
+            const result = await userRepository.findByIdRaw({ args: ["missing"] });
+
+            expect(result).toBeNull();
+        });
+
+        it("'activateUserRaw' (modifying + singleResult: true) mantém o valor original quando o resultado não é um array", async () => {
+            fakeAdapter.query.mockResolvedValueOnce(1);
+
+            const result = await userRepository.activateUserRaw({ args: ["user-1"] });
+
+            expect(fakeAdapter.query).toHaveBeenCalledWith(
+                'UPDATE "user" SET active = true WHERE id = $1',
+                expect.objectContaining({ args: ["user-1"], modifying: true }),
+            );
+            expect(result).toBe(1);
+        });
+    });
 });

--- a/test/implementation/error-handling.test.ts
+++ b/test/implementation/error-handling.test.ts
@@ -161,21 +161,15 @@ describe("VSRepository — guard clauses dos métodos base", () => {
     const userRepository = new UserRepository(createFakeAdapter<User>());
 
     it("'removeList' é lançado quando 'pks' não é um array", async () => {
-        await expect(userRepository.removeList("not-an-array" as any)).rejects.toThrow(
-            VSRepoError,
-        );
+        await expect(userRepository.removeList("not-an-array" as any)).rejects.toThrow(VSRepoError);
     });
 
     it("'saveList' é lançado quando 'objs' não é um array", async () => {
-        await expect(userRepository.saveList("not-an-array" as any)).rejects.toThrow(
-            VSRepoError,
-        );
+        await expect(userRepository.saveList("not-an-array" as any)).rejects.toThrow(VSRepoError);
     });
 
     it("'getList' é lançado quando 'pks' não é um array", async () => {
-        await expect(userRepository.getList("not-an-array" as any)).rejects.toThrow(
-            VSRepoError,
-        );
+        await expect(userRepository.getList("not-an-array" as any)).rejects.toThrow(VSRepoError);
     });
 
     it("'transaction' é lançado quando 'fn' não é uma função", async () => {
@@ -200,6 +194,48 @@ describe("VSRepository — guard clauses dos métodos base", () => {
             expect(err instanceof VSRepoError).toBe(true);
             expect((err as VSRepoError).type).toBe(VSRepoErrorType.BASE);
         }
+    });
+});
+
+// =============================================================================
+// VSRepoErrorType.DYNAMIC — @QueryMethod chamado com uma assinatura que não
+// bate com 'spreadArgs' (o modo é decidido na declaração, não na chamada).
+// =============================================================================
+
+describe("@QueryMethod — validação da assinatura de chamada ('spreadArgs')", () => {
+    class UserRepository extends VSRepository<User, string> {
+        constructor(adapter: VSRepoAdapter<User>) {
+            super({ adapter, pkName: "id" });
+        }
+
+        @QueryMethod('SELECT * FROM "user" WHERE email = $1')
+        declare findByEmailRaw: (arg: any) => Promise<User[]>;
+    }
+
+    const userRepository = new UserRepository(createFakeAdapter<User>());
+
+    it("é lançado ao chamar um método declarado sem 'spreadArgs' com mais de um argumento posicional", async () => {
+        await expect(
+            (userRepository.findByEmailRaw as any)("joao@email.com", "extra"),
+        ).rejects.toThrow(VSRepoError);
+    });
+
+    it("tem type 'DYNAMIC'", async () => {
+        try {
+            await (userRepository.findByEmailRaw as any)("joao@email.com", "extra");
+            throw new Error("deveria ter lançado VSRepoError");
+        } catch (err) {
+            expect(err instanceof VSRepoError).toBe(true);
+            expect((err as VSRepoError).type).toBe(VSRepoErrorType.DYNAMIC);
+        }
+    });
+
+    it("não lança ao chamar com um único 'QueryMethodArg' (assinatura padrão)", async () => {
+        const fakeAdapter = createFakeAdapter<User>();
+        const repo = new UserRepository(fakeAdapter);
+        fakeAdapter.query.mockResolvedValueOnce([]);
+
+        await expect(repo.findByEmailRaw({ args: ["joao@email.com"] })).resolves.toEqual([]);
     });
 });
 


### PR DESCRIPTION
This pull request introduces two major new features to the repository API: the `singleResult` and `spreadArgs` options for query methods, along with their associated types and documentation. Both English and Portuguese documentation have been updated, and new implementation tests and JSDoc comments are included. The most important changes are summarized below.

---

### New Query Method Options

* Added `singleResult` option to `@QueryMethod` and `query()`, which collapses an array result into its first element (or `null` if empty), making it easier to work with queries that return at most one row. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R36) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R602-R649) [[3]](diffhunk://#diff-1429a5f8afc794182301e346da630d8884661cc020c677dbdbd2fac7dfcd16c2R602-R649) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R661-R675) [[5]](diffhunk://#diff-1429a5f8afc794182301e346da630d8884661cc020c677dbdbd2fac7dfcd16c2R661-R675)
* Added `spreadArgs` option to `@QueryMethod`, allowing SQL placeholder values to be passed as separate positional arguments (JpaRepository style), instead of a single `QueryMethodArg` object. This includes call-arity validation and the new `DbArg<T>`/`withDb()` utility for passing a database client or transaction. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R36) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R54) [[3]](diffhunk://#diff-1429a5f8afc794182301e346da630d8884661cc020c677dbdbd2fac7dfcd16c2R54) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R736) [[5]](diffhunk://#diff-1429a5f8afc794182301e346da630d8884661cc020c677dbdbd2fac7dfcd16c2R739)

### Type and API Improvements

* Introduced new public type `QueryArgs<T, O>`, which types the spread parameter list for `@QueryMethod` with `spreadArgs: true`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R36) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R736) [[3]](diffhunk://#diff-1429a5f8afc794182301e346da630d8884661cc020c677dbdbd2fac7dfcd16c2R739)
* Made `QueryMethodOptions.modifying` optional in the type definition, defaulting to `false` at runtime for consistency with decorator behavior.

### Documentation and Testing

* Updated both English (`README.md`) and Portuguese (`README.pt-BR.md`) documentation to cover `singleResult`, `spreadArgs`, `DbArg`, `withDb`, and `QueryArgs`, including usage examples and option tables. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R602-R649) [[2]](diffhunk://#diff-1429a5f8afc794182301e346da630d8884661cc020c677dbdbd2fac7dfcd16c2R602-R649) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R661-R675) [[4]](diffhunk://#diff-1429a5f8afc794182301e346da630d8884661cc020c677dbdbd2fac7dfcd16c2R661-R675)
* Added implementation tests for the new options and documented all new types and functions with JSDoc.

---

These enhancements make query methods more ergonomic and type-safe, especially for single-row lookups and for repositories with varying query argument styles.